### PR TITLE
Adjust end-to-end test 11 (mef_eline) to wait some time after the linkDown event

### DIFF
--- a/tests/test_e2e_11_mef_eline.py
+++ b/tests/test_e2e_11_mef_eline.py
@@ -68,6 +68,9 @@ class TestE2EMefEline(unittest.TestCase):
         """ Command to up/down links to test if back-up path is taken with the following command: """
         self.net.net.configLinkStatus('s1', 's2', 'down')
 
+        # wait just a few seconds to give time to the controller receive and process the linkDown event
+        time.sleep(2)
+
         """Check on the virtual switches directly for flows.
         Each switch that the flow traveled must have 3 flows:
         01 for LLDP + 02 for the EVC (ingress + egress)"""


### PR DESCRIPTION
This pull request just add a wait time before checking the flow table after a LinkDown event on tests/test_e2e_11_mef_eline.py.

This will fix the following error on the end-to-end testing process:

```
______ TestE2EMefEline.test_on_primary_path_fail_should_migrate_to_backup ______

self = <tests.test_e2e_11_mef_eline.TestE2EMefEline testMethod=test_on_primary_path_fail_should_migrate_to_backup>

   def test_on_primary_path_fail_should_migrate_to_backup(self):
       # TODO Check for false positives between uni_a switch 1 and uni_z switch 3 instead of switch 2
       """ When the primary_path is down and backup_path exists and is UP
           the circuit will change from primary_path to backup_path. """
       self.net.restart_kytos_clean()
       time.sleep(10)
       payload = {
           "name": "my evc1",
           "enabled": True,
           "uni_a": {
               "interface_id": "00:00:00:00:00:00:00:01:1",
               "tag": {
                   "tag_type": 1,
                   "value": 101
               }
           },
           "uni_z": {
               "interface_id": "00:00:00:00:00:00:00:02:1",
               "tag": {
                   "tag_type": 1,
                   "value": 101
               }
           },
           "primary_path": [
               {"endpoint_a": {"id": "00:00:00:00:00:00:00:01:3"},
                "endpoint_b": {"id": "00:00:00:00:00:00:00:02:3"}}
           ],
           "backup_path": [
               {"endpoint_a": {"id": "00:00:00:00:00:00:00:01:4"},
                "endpoint_b": {"id": "00:00:00:00:00:00:00:04:4"}},
               {"endpoint_a": {"id": "00:00:00:00:00:00:00:04:3"},
                "endpoint_b": {"id": "00:00:00:00:00:00:00:03:4"}},
               {"endpoint_a": {"id": "00:00:00:00:00:00:00:03:1"},
                "endpoint_b": {"id": "00:00:00:00:00:00:00:02:4"}}
           ]
       }

       api_url = KYTOS_API + '/mef_eline/v2/evc/'
       response = requests.post(api_url, json=payload)
       assert response.status_code == 201

       time.sleep(10)

       """ Command to up/down links to test if back-up path is taken with the following command: """
       self.net.net.configLinkStatus('s1', 's2', 'down')

       """Check on the virtual switches directly for flows.
       Each switch that the flow traveled must have 3 flows:
       01 for LLDP + 02 for the EVC (ingress + egress)"""
       s1, s2, s3, s4 = self.net.net.get('s1', 's2', 's3', 's4')
       flows_s1 = s1.dpctl('dump-flows')
       flows_s2 = s2.dpctl('dump-flows')
       flows_s3 = s3.dpctl('dump-flows')
       flows_s4 = s4.dpctl('dump-flows')
       assert len(flows_s1.split('\r\n ')) == 3
       assert len(flows_s2.split('\r\n ')) == 3
     assert len(flows_s3.split('\r\n ')) == 3
E       AssertionError: assert 1 == 3
E        +  where 1 = len([' cookie=0x0, duration=3.334s, table=0, n_packets=14, n_bytes=588, priority=1000,dl_vlan=3799,dl_type=0x88cc actions=CONTROLLER:65535\r\n'])
E        +    where [' cookie=0x0, duration=3.334s, table=0, n_packets=14, n_bytes=588, priority=1000,dl_vlan=3799,dl_type=0x88cc actions=CONTROLLER:65535\r\n'] = <built-in method split of str object at 0x5644982304b0>('\r\n ')
E        +      where <built-in method split of str object at 0x5644982304b0> = ' cookie=0x0, duration=3.334s, table=0, n_packets=14, n_bytes=588, priority=1000,dl_vlan=3799,dl_type=0x88cc actions=CONTROLLER:65535\r\n'.split
```