### PR TITLE
Consolidating a common tests setting

### DIFF
--- a/tests/test_e2e_01_kytos_startup.py
+++ b/tests/test_e2e_01_kytos_startup.py
@@ -1,3 +1,5 @@
+import time
+
 import requests
 from tests.helpers import NetworkTest
 import re
@@ -16,17 +18,23 @@ class TestE2EKytosServer:
 
     def setup_method(self, method):
         """
-        It is called at the beginning of the class execution
+        It is called at the beginning of every class method execution
         """
-        self.net = NetworkTest(CONTROLLER)
-        self.net.start()
+        # Start the controller setting an environment in
+        # which all elements are disabled in a clean setting
+        self.net.start_controller(clean_config=True, enable_all=False)
         self.net.wait_switches_connect()
+        time.sleep(5)
 
-    def teardown_method(self, method):
-        """
-        It is called everytime a method ends it execution
-        """
-        self.net.stop()
+    @classmethod
+    def setup_class(cls):
+        cls.net = NetworkTest(CONTROLLER)
+        cls.net.start()
+        cls.net.wait_switches_connect()
+
+    @classmethod
+    def teardown_class(cls):
+        cls.net.stop()
 
     def test_start_kytos_api_core(self):
 

--- a/tests/test_e2e_05_topology.py
+++ b/tests/test_e2e_05_topology.py
@@ -1,4 +1,3 @@
-import pytest
 import json
 import requests
 from tests.helpers import NetworkTest
@@ -13,27 +12,25 @@ class TestE2ETopology:
 
     def setup_method(self, method):
         """
-        It is called at the beginning of the class execution
+        It is called at the beginning of every class method execution
         """
-        self.net = NetworkTest(CONTROLLER)
-        self.net.start()
-        self.net.wait_switches_connect()
-    
-    def teardown_method(self, method):
-        """
-        It is called everytime a method ends it execution
-        """
-        self.net.stop()
-    
-    @pytest.fixture
-    def restart_kytos(self):
-
         # Start the controller setting an environment in
         # which all elements are disabled in a clean setting
         self.net.start_controller(clean_config=True, enable_all=False)
         self.net.wait_switches_connect()
+        time.sleep(5)
 
-    def test_010_list_switches(self, restart_kytos):
+    @classmethod
+    def setup_class(cls):
+        cls.net = NetworkTest(CONTROLLER)
+        cls.net.start()
+        cls.net.wait_switches_connect()
+
+    @classmethod
+    def teardown_class(cls):
+        cls.net.stop()
+
+    def test_010_list_switches(self):
         """
         Test /api/kytos/topology/v3/ on GET
         """
@@ -48,7 +45,7 @@ class TestE2ETopology:
         assert '00:00:00:00:00:00:00:02' in data['switches']
         assert '00:00:00:00:00:00:00:03' in data['switches']
 
-    def test_020_enabling_switch_persistent(self, restart_kytos):
+    def test_020_enabling_switch_persistent(self):
         """
         Test /api/kytos/topology/v3/switches/{dpid}/enable on POST
         supported by
@@ -96,7 +93,7 @@ class TestE2ETopology:
         data = response.json()
         assert data['switches'][switch_id]['enabled'] is True
 
-    def test_030_disabling_switch_persistent(self, restart_kytos):
+    def test_030_disabling_switch_persistent(self):
         """
         Test /api/kytos/topology/v3/switches/{dpid}/disable on POST
         supported by
@@ -144,7 +141,7 @@ class TestE2ETopology:
         data = response.json()
         assert data['switches'][switch_id]['enabled'] is False
 
-    def test_040_removing_switch_metadata_persistent(self, restart_kytos):
+    def test_040_removing_switch_metadata_persistent(self):
         """
         Test /api/kytos/topology/v3/switches/{dpid}/metadata/{key} on DELETED
         supported by:
@@ -197,7 +194,7 @@ class TestE2ETopology:
         keys = data['metadata'].keys()
         assert key not in keys
 
-    def test_050_enabling_interface_persistent(self, restart_kytos):
+    def test_050_enabling_interface_persistent(self):
         """
         Test /api/kytos/topology/v3/interfaces/{interface_id}/enable on POST
         supported by
@@ -232,7 +229,7 @@ class TestE2ETopology:
         data = response.json()
         assert data['interfaces'][interface_id]['enabled'] is True
 
-    def test_060_enabling_all_interfaces_on_a_switch_persistent(self, restart_kytos):
+    def test_060_enabling_all_interfaces_on_a_switch_persistent(self):
         """
         Test /api/kytos/topology/v3/interfaces/switch/{dpid}/enable on POST
         supported by
@@ -270,7 +267,7 @@ class TestE2ETopology:
         for interface in data['switches'][switch_id]['interfaces']:
             assert data['switches'][switch_id]['interfaces'][interface]['enabled'] is True
 
-    def test_070_disabling_interface_persistent(self, restart_kytos):
+    def test_070_disabling_interface_persistent(self):
         """
         Test /api/kytos/topology/v3/interfaces/{interface_id}/disable on POST
         supported by:
@@ -317,7 +314,7 @@ class TestE2ETopology:
         data = response.json()
         assert data['interfaces'][interface_id]['enabled'] is False
 
-    def test_080_disabling_all_interfaces_on_a_switch_persistent(self, restart_kytos):
+    def test_080_disabling_all_interfaces_on_a_switch_persistent(self):
         """
         Test /api/kytos/topology/v3/interfaces/{interface_id}/disable on POST
         supported by:
@@ -349,7 +346,7 @@ class TestE2ETopology:
         for interface in data['switches'][switch_id]['interfaces']:
             assert data['switches'][switch_id]['interfaces'][interface]['enabled'] is True
 
-    def test_090_removing_interfaces_metadata_persistent(self, restart_kytos):
+    def test_090_removing_interfaces_metadata_persistent(self):
         """
         Test /api/kytos/topology/v3/interfaces/{interface_id}/metadata/{key} on DELETE
         supported by:
@@ -404,7 +401,7 @@ class TestE2ETopology:
         keys = data['metadata'].keys()
         assert key not in keys
 
-    def test_100_enabling_link_persistent(self, restart_kytos):
+    def test_100_enabling_link_persistent(self):
         """
         Test /api/kytos/topology/v3/links/{link_id}/enable on POST
         supported by:
@@ -474,7 +471,7 @@ class TestE2ETopology:
         data = response.json()
         assert data['links'][link_id1]['enabled'] is True
 
-    def test_110_disabling_link_persistent(self, restart_kytos):
+    def test_110_disabling_link_persistent(self):
         """
         Test /api/kytos/topology/v3/links/{link_id}/disable on POST
         supported by:
@@ -569,7 +566,7 @@ class TestE2ETopology:
         data = response.json()
         assert data['links'][link_id1]['enabled'] is False
 
-    def test_120_removing_link_metadata_persistent(self, restart_kytos):
+    def test_120_removing_link_metadata_persistent(self):
         """
         Test /api/kytos/topology/v3/links/{link_id}/metadata/{key} on DELETE
         supported by:
@@ -669,7 +666,7 @@ class TestE2ETopology:
         keys = data['metadata'].keys()
         assert key not in keys
 
-    def test_200_switch_disabled_on_clean_start(self, restart_kytos):
+    def test_200_switch_disabled_on_clean_start(self):
 
         switch_id = "00:00:00:00:00:00:00:01"
 
@@ -681,7 +678,7 @@ class TestE2ETopology:
         assert response.status_code == 200
         assert data['switches'][switch_id]['enabled'] is False
 
-    def test_300_interfaces_disabled_on_clean_start(self, restart_kytos):
+    def test_300_interfaces_disabled_on_clean_start(self):
 
         # Make sure the interfaces are disabled
         api_url = KYTOS_API + '/topology/v3/interfaces'
@@ -694,8 +691,8 @@ class TestE2ETopology:
 
         # Start the controller setting an environment in
         # which all elements are disabled in a clean setting
-        self.net.start_controller(clean_config=True, enable_all=True)
-        self.net.wait_switches_connect()
+        # self.net.start_controller(clean_config=True, enable_all=True)
+        # self.net.wait_switches_connect()
 
         # Make sure the switch is disabled
         api_url = KYTOS_API + '/topology/v3/switches'
@@ -710,8 +707,8 @@ class TestE2ETopology:
 
         # Start the controller setting an environment in
         # which all elements are disabled in a clean setting
-        self.net.start_controller(clean_config=True, enable_all=True)
-        self.net.wait_switches_connect()
+        # self.net.start_controller(clean_config=True, enable_all=True)
+        # self.net.wait_switches_connect()
 
         # Make sure the interfaces are disabled
         api_url = KYTOS_API + '/topology/v3/interfaces'

--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -10,6 +10,16 @@ KYTOS_API = 'http://%s:8181/api/kytos' % CONTROLLER
 class TestE2EFlowManager:
     net = None
 
+    def setup_method(self, method):
+        """
+        It is called at the beginning of every class method execution
+        """
+        # Start the controller setting an environment in
+        # which all elements are disabled in a clean setting
+        self.net.start_controller(clean_config=True, enable_all=False)
+        self.net.wait_switches_connect()
+        time.sleep(5)
+
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER)
@@ -23,8 +33,8 @@ class TestE2EFlowManager:
     def test_020_install_flow(self):
         """Test if, after kytos restart, a flow installed to a switch will
            still be installed."""
-        self.net.restart_kytos_clean()
-        time.sleep(5)
+        # self.net.restart_kytos_clean()
+        # time.sleep(5)
 
         payload = {
             "flows": [
@@ -68,8 +78,8 @@ class TestE2EFlowManager:
     def test_020_install_flows(self):
         """Test if, after kytos restart, a flow installed to all switches will
            still be installed."""
-        self.net.restart_kytos_clean()
-        time.sleep(5)
+        # self.net.restart_kytos_clean()
+        # time.sleep(5)
 
         payload = {
             "flows": [
@@ -114,8 +124,8 @@ class TestE2EFlowManager:
     def test_020_delete_flow(self):
         """Test if, after kytos restart, a flow deleted from a switch will
            still be deleted."""
-        self.net.restart_kytos_clean()
-        time.sleep(5)
+        # self.net.restart_kytos_clean()
+        # time.sleep(5)
 
         payload = {
             "flows": [
@@ -170,8 +180,8 @@ class TestE2EFlowManager:
     def test_020_delete_flows(self):
         """Test if, after kytos restart, a flow deleted from all switches will
            still be deleted."""
-        self.net.restart_kytos_clean()
-        time.sleep(5)
+        # self.net.restart_kytos_clean()
+        # time.sleep(5)
 
         payload = {
             "flows": [
@@ -227,8 +237,8 @@ class TestE2EFlowManager:
     def modify_match(self, restart_kytos=False):
         """Test if after a match is modified outside kytos, the original
            flow is restored."""
-        self.net.restart_kytos_clean()
-        time.sleep(5)
+        # self.net.restart_kytos_clean()
+        # time.sleep(5)
 
         payload = {
             "flows": [
@@ -281,9 +291,8 @@ class TestE2EFlowManager:
         self.modify_match(restart_kytos=True)
 
     def replace_action_flow(self, restart_kytos=False):
-
-        self.net.restart_kytos_clean()
-        time.sleep(5)
+        # self.net.restart_kytos_clean()
+        # time.sleep(5)
 
         payload = {
             "flows": [
@@ -346,9 +355,8 @@ class TestE2EFlowManager:
         self.replace_action_flow(restart_kytos=True)
 
     def add_action_flow(self, restart_kytos=False):
-
-        self.net.restart_kytos_clean()
-        time.sleep(5)
+        # self.net.restart_kytos_clean()
+        # time.sleep(5)
 
         payload = {
             "flows": [
@@ -404,8 +412,8 @@ class TestE2EFlowManager:
     def flow_another_table(self, restart_kytos=False):
         """Test if, after adding a flow in another table outside kytos, the 
             flow is removed."""
-        self.net.restart_kytos_clean()
-        time.sleep(5)
+        # self.net.restart_kytos_clean()
+        # time.sleep(5)
 
         s1 = self.net.net.get('s1')
         s1.dpctl('add-flow', 'table=2,in_port=1,actions=output:2')
@@ -428,8 +436,8 @@ class TestE2EFlowManager:
     def flow_table_0(self, restart_kytos=False):
         """Test if, after adding a flow in another table outside kytos, the
             flow is removed."""
-        self.net.restart_kytos_clean()
-        time.sleep(5)
+        # self.net.restart_kytos_clean()
+        # time.sleep(5)
 
         s1 = self.net.net.get('s1')
         s1.dpctl('add-flow', 'table=0,in_port=1,actions=output:2')

--- a/tests/test_e2e_21_flow_manager.py
+++ b/tests/test_e2e_21_flow_manager.py
@@ -1,16 +1,25 @@
 import json
-import pytest
 import requests
 from tests.helpers import NetworkTest
-import os
 import time
 import re
 
 CONTROLLER = '127.0.0.1'
 KYTOS_API = 'http://%s:8181/api/kytos' % CONTROLLER
 
+
 class TestE2EFlowManager:
     net = None
+
+    def setup_method(self, method):
+        """
+        It is called at the beginning of every class method execution
+        """
+        # Start the controller setting an environment in
+        # which all elements are disabled in a clean setting
+        self.net.start_controller(clean_config=True, enable_all=False)
+        self.net.wait_switches_connect()
+        time.sleep(5)
 
     @classmethod
     def setup_class(cls):
@@ -25,8 +34,6 @@ class TestE2EFlowManager:
     def test_030_restart_kytos_should_preserve_flows(self):
         """Test if, after kytos restart, the flows are preserved on the switch
            flow table."""
-        self.net.restart_kytos_clean()
-        time.sleep(5)
 
         payload = {
             "flows": [
@@ -78,8 +85,6 @@ class TestE2EFlowManager:
     def test_031_on_switch_restart_kytos_should_recreate_flows(self):
         """Test if, after kytos restart, the flows are preserved on the switch 
            flow table."""
-        self.net.restart_kytos_clean()
-        time.sleep(5)
 
         payload = {
             "flows": [


### PR DESCRIPTION
A common way to set up, tear down, and restart the controller for all the class instantiations and class methods calls has been specified.