### PR TITLE
Unifying all the tests to follow the same testing process approach

### DIFF
--- a/tests/test_e2e_05_topology.py
+++ b/tests/test_e2e_05_topology.py
@@ -18,13 +18,14 @@ class TestE2ETopology:
         # which all elements are disabled in a clean setting
         self.net.start_controller(clean_config=True, enable_all=False)
         self.net.wait_switches_connect()
-        time.sleep(5)
+        time.sleep(10)
 
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER)
         cls.net.start()
         cls.net.wait_switches_connect()
+        time.sleep(5)
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -1,12 +1,10 @@
-import unittest
 import requests
 from tests.helpers import NetworkTest
-import os
 import time
 import json
 
 CONTROLLER = '127.0.0.1'
-KYTOS_API = 'http://%s:8181/api/kytos' % (CONTROLLER)
+KYTOS_API = 'http://%s:8181/api/kytos' % CONTROLLER
 
 
 class TestE2EMefEline:
@@ -34,14 +32,14 @@ class TestE2EMefEline:
     def teardown_class(cls):
         cls.net.stop()
 
-    def test_001_list_evcs_should_be_empty(self):
+    def test_010_list_evcs_should_be_empty(self):
         """Test if list circuits return 'no circuit stored.'."""
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.get(api_url)
         assert response.status_code == 200
         assert response.json() == {}
 
-    def test_010_create_evc_intra_switch(self):
+    def test_015_create_evc_intra_switch(self):
         """ create an intra-switch EVC e-line with VLAN tag
         (UNIs in the same switch) """
         payload = {
@@ -93,8 +91,7 @@ class TestE2EMefEline:
         h12.cmd('ip link del vlan101')
         self.net.restart_kytos_clean()
 
-    def test_015_create_evc_inter_switch(self):
-        time.sleep(10)
+    def test_020_create_evc_inter_switch(self):
         payload = {
             "name": "my evc1",
             "enabled": True,
@@ -124,9 +121,8 @@ class TestE2EMefEline:
         # Each switch must have 3 flows: 01 for LLDP + 02 for the EVC (ingress + egress)
         s1, s2 = self.net.net.get('s1', 's2')
         flows_s1 = s1.dpctl('dump-flows')
-        print(flows_s1)
         flows_s2 = s2.dpctl('dump-flows')
-        print(flows_s2)
+
         assert len(flows_s1.split('\r\n ')) == 3
         assert len(flows_s2.split('\r\n ')) == 3
 
@@ -152,8 +148,7 @@ class TestE2EMefEline:
         h2.cmd('ip link del vlan15')
         self.net.restart_kytos_clean()
 
-    def test_020_create_evc_different_tags_each_side(self):
-        time.sleep(10)
+    def test_025_create_evc_different_tags_each_side(self):
         payload = {
             "name": "Vlan102_103_Test",
             "enabled": True,
@@ -203,9 +198,7 @@ class TestE2EMefEline:
         h2.cmd('ip link del vlan103')
         self.net.restart_kytos_clean()
 
-    def test_020_create_evc_tag_notag(self):
-        self.net.restart_kytos_clean()
-        time.sleep(10)
+    def test_030_create_evc_tag_notag(self):
         payload = {
             "name": "Vlan104_Test",
             "enabled": True,
@@ -254,10 +247,8 @@ class TestE2EMefEline:
         h2.cmd('ip addr del 104.0.0.2/24 dev %s' % (h2.intfNames()[0]))
         self.net.restart_kytos_clean()
 
-    def test_020_create_evc_same_vid_different_uni(self):
+    def test_035_create_evc_same_vid_different_uni(self):
         # Create circuit 1
-        self.net.restart_kytos_clean()
-        time.sleep(10)
         payload = {
             "name": "Vlan110_Test",
             "enabled": True,
@@ -349,11 +340,9 @@ class TestE2EMefEline:
         h3.cmd('ip link del vlan110')
         self.net.restart_kytos_clean()
 
-    def test_025_disable_circuit_should_remove_openflow_rules(self):
+    def test_040_disable_circuit_should_remove_openflow_rules(self):
         # let's suppose that xyz is the circuit id previously created
         # curl -X PATCH -H "Content-Type: application/json" -d '{"enable": false}' http://172.18.0.2:8181/api/kytos/mef_eline/v2/evc/xyz
-        self.net.restart_kytos_clean()
-        time.sleep(10)
         payload = {
             "name": "Vlan125_Test_evc1",
             "enabled": True,
@@ -404,9 +393,7 @@ class TestE2EMefEline:
         h11.cmd('ip link del vlan125')
         h2.cmd('ip link del vlan125')
 
-    def test_025_create_circuit_reusing_same_vlanid_from_previous_evc(self):
-        self.net.restart_kytos_clean()
-        time.sleep(10)
+    def test_045_create_circuit_reusing_same_vlanid_from_previous_evc(self):
         payload = {
             "name": "Vlan125_Test_evc1",
             "enabled": True,
@@ -481,19 +468,19 @@ class TestE2EMefEline:
         h2.cmd('ip link del vlan125')
         self.net.restart_kytos_clean()
 
-    def test_030_patch_evc_new_name(self):
+    def test_050_patch_evc_new_name(self):
         # TODO
         assert True
 
-    def test_040_patch_evc_new_unis(self):
+    def test_055_patch_evc_new_unis(self):
         # TODO
         assert True
 
-    def test_050_disable_evc(self):
+    def test_060_disable_evc(self):
         # TODO
         assert True
 
-    def test_060_on_primary_path_fail_should_migrate_to_backup(self):
+    def test_065_on_primary_path_fail_should_migrate_to_backup(self):
         # TODO
         assert True
 

--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -9,25 +9,37 @@ CONTROLLER = '127.0.0.1'
 KYTOS_API = 'http://%s:8181/api/kytos' % (CONTROLLER)
 
 
-class TestE2EMefEline(unittest.TestCase):
+class TestE2EMefEline:
     net = None
 
+    def setup_method(self, method):
+        """
+        It is called at the beginning of every class method execution
+        """
+        # Start the controller setting an environment in
+        # which all elements are disabled in a clean setting
+        self.net.start_controller(clean_config=True, enable_all=True)
+        self.net.wait_switches_connect()
+        time.sleep(10)
+
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER)
         cls.net.start()
         cls.net.restart_kytos_clean()
+        cls.net.wait_switches_connect()
+        time.sleep(5)
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         cls.net.stop()
 
     def test_001_list_evcs_should_be_empty(self):
         """Test if list circuits return 'no circuit stored.'."""
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.get(api_url)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {})
+        assert response.status_code == 200
+        assert response.json() == {}
 
     def test_010_create_evc_intra_switch(self):
         """ create an intra-switch EVC e-line with VLAN tag
@@ -52,7 +64,7 @@ class TestE2EMefEline(unittest.TestCase):
         }
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, json=payload)
-        self.assertEqual(response.status_code, 201)
+        assert response.status_code == 201
         data = response.json()
         assert 'circuit_id' in data
         time.sleep(20)

--- a/tests/test_e2e_12_mef_eline.py
+++ b/tests/test_e2e_12_mef_eline.py
@@ -37,7 +37,7 @@ class TestE2EMefEline:
     def disabled_circuit_id(self, circuit_id):
         self._disable_circuit(circuit_id)
         time.sleep(2)
-        return circuit_id    
+        return circuit_id
 
     def _circuit_exists(self, circuit_id):
         api_url = KYTOS_API + '/mef_eline/v2/evc/' + circuit_id
@@ -76,8 +76,8 @@ class TestE2EMefEline:
         response = requests.patch(api_url, json=payload)
 
         assert response.status_code == 200
-        
-        return 
+
+        return
 
     def test_create_schedule_by_frequency(self, disabled_circuit_id):
         """ Test scheduler creation to enable the circuit by frequency, 
@@ -85,11 +85,11 @@ class TestE2EMefEline:
 
         # Schedule by frequency every minute
         payload = {
-              "circuit_id":disabled_circuit_id,
-              "schedule": {
+            "circuit_id": disabled_circuit_id,
+            "schedule": {
                 "frequency": "* * * * *"
-              }
             }
+        }
 
         # verify if the circuit is really disabled
         api_url = KYTOS_API + '/mef_eline/v2/evc/' + disabled_circuit_id
@@ -100,8 +100,8 @@ class TestE2EMefEline:
         # create circuit schedule
         api_url = KYTOS_API + '/mef_eline/v2/evc/schedule'
         response = requests.post(api_url, json=payload)
-        assert response.status_code == 201  
-        
+        assert response.status_code == 201
+
         # waiting some time to trigger the scheduler
         time.sleep(62)
 
@@ -127,11 +127,11 @@ class TestE2EMefEline:
         schedule_time = ts.strftime("%Y-%m-%dT%H:%M:%S.000Z")
 
         payload = {
-              "circuit_id":disabled_circuit_id,
-              "schedule": {
+            "circuit_id": disabled_circuit_id,
+            "schedule": {
                 "date": schedule_time
-              }
             }
+        }
 
         # verify if the circuit is really disabled
         api_url = KYTOS_API + '/mef_eline/v2/evc/' + disabled_circuit_id
@@ -142,8 +142,8 @@ class TestE2EMefEline:
         # create circuit schedule
         api_url = KYTOS_API + '/mef_eline/v2/evc/schedule'
         response = requests.post(api_url, json=payload)
-        assert response.status_code == 201  
-        
+        assert response.status_code == 201
+
         # waiting some time to trigger the scheduler
         time.sleep(62)
 
@@ -158,17 +158,17 @@ class TestE2EMefEline:
         scheduler_date = json.get("circuit_scheduler")[0].get("date")
         payload_date = payload.get("schedule").get("date")
         assert payload_date == scheduler_date
-     
+
     def test_delete_schedule(self, circuit_id):
         """ Test to delete a scheduler. """
 
         # Schedule by frequency every minute
         payload = {
-              "circuit_id":circuit_id,
-              "schedule": {
+            "circuit_id": circuit_id,
+            "schedule": {
                 "frequency": "* * * * *"
-              }
             }
+        }
 
         # create circuit schedule
         api_url = KYTOS_API + '/mef_eline/v2/evc/schedule'
@@ -197,11 +197,11 @@ class TestE2EMefEline:
 
         # Schedule by frequency every hour
         payload = {
-              "circuit_id":disabled_circuit_id,
-              "schedule": {
+            "circuit_id": disabled_circuit_id,
+            "schedule": {
                 "frequency": "* 1 * * *"
-              }
             }
+        }
 
         # create circuit schedule
         api_url = KYTOS_API + '/mef_eline/v2/evc/schedule'

--- a/tests/test_e2e_12_mef_eline.py
+++ b/tests/test_e2e_12_mef_eline.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-import json
 import pytest
 import requests
 import time
@@ -9,13 +8,15 @@ CONTROLLER = '127.0.0.1'
 KYTOS_API = 'http://%s:8181/api/kytos' % CONTROLLER
 
 
-class TestE2EMefEline():
+class TestE2EMefEline:
     net = None
 
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER)
         cls.net.start()
+        cls.net.wait_switches_connect()
+        time.sleep(10)
 
     @classmethod
     def teardown_class(cls):
@@ -24,6 +25,8 @@ class TestE2EMefEline():
     @pytest.fixture()
     def kytos_clean(self):
         self.net.restart_kytos_clean()
+        self.net.wait_switches_connect()
+        time.sleep(10)
 
     @pytest.fixture()
     def circuit_id(self, kytos_clean):
@@ -91,8 +94,8 @@ class TestE2EMefEline():
         # verify if the circuit is really disabled
         api_url = KYTOS_API + '/mef_eline/v2/evc/' + disabled_circuit_id
         response = requests.get(api_url)
-        json = response.json() 
-        assert json.get("enabled") == False
+        json = response.json()
+        assert json.get("enabled") is False
 
         # create circuit schedule
         api_url = KYTOS_API + '/mef_eline/v2/evc/schedule'
@@ -107,9 +110,9 @@ class TestE2EMefEline():
         response = requests.get(api_url)
         assert response.status_code == 200
 
-        json = response.json() 
-        assert json.get("enabled") == True
-        
+        json = response.json()
+        assert json.get("enabled") is True
+
         scheduler_frq = json.get("circuit_scheduler")[0].get("frequency")
         payload_frq = payload.get("schedule").get("frequency")
         assert scheduler_frq is not None
@@ -133,8 +136,8 @@ class TestE2EMefEline():
         # verify if the circuit is really disabled
         api_url = KYTOS_API + '/mef_eline/v2/evc/' + disabled_circuit_id
         response = requests.get(api_url)
-        json = response.json() 
-        assert json.get("enabled") == False
+        json = response.json()
+        assert json.get("enabled") is False
 
         # create circuit schedule
         api_url = KYTOS_API + '/mef_eline/v2/evc/schedule'
@@ -149,8 +152,8 @@ class TestE2EMefEline():
         response = requests.get(api_url)
         assert response.status_code == 200
 
-        json = response.json() 
-        assert json.get("enabled") == True
+        json = response.json()
+        assert json.get("enabled") is True
 
         scheduler_date = json.get("circuit_scheduler")[0].get("date")
         payload_date = payload.get("schedule").get("date")
@@ -213,7 +216,7 @@ class TestE2EMefEline():
         api_url = KYTOS_API + '/mef_eline/v2/evc/' + disabled_circuit_id
         response = requests.get(api_url)
         json = response.json()
-        assert json.get("enabled") == False
+        assert json.get("enabled") is False
 
         # Schedule by frequency every minute
         payload = {
@@ -234,7 +237,7 @@ class TestE2EMefEline():
         json = response.json()
 
         assert response.status_code == 200
-        assert json.get("enabled") == True
+        assert json.get("enabled") is True
 
         frequency = json.get("circuit_scheduler")[0].get("frequency")
         assert payload.get("frequency") == frequency

--- a/tests/test_e2e_15_maintenance.py
+++ b/tests/test_e2e_15_maintenance.py
@@ -1,7 +1,5 @@
-import unittest
 import requests
 from tests.helpers import NetworkTest
-import os
 import time
 import json
 from datetime import datetime, timedelta
@@ -11,16 +9,19 @@ KYTOS_API = 'http://%s:8181/api/kytos' % (CONTROLLER)
 
 TIME_FMT = "%Y-%m-%dT%H:%M:%S+0000"
 
-class TestE2EMaintenance(unittest.TestCase):
+
+class TestE2EMaintenance:
     net = None
+
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER)
         cls.net.start()
         cls.net.restart_kytos_clean()
+        time.sleep(10)
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         cls.net.stop()
 
     def create_circuit(self, vlan_id):

--- a/tests/test_e2e_15_maintenance.py
+++ b/tests/test_e2e_15_maintenance.py
@@ -5,7 +5,7 @@ import json
 from datetime import datetime, timedelta
 
 CONTROLLER = '127.0.0.1'
-KYTOS_API = 'http://%s:8181/api/kytos' % (CONTROLLER)
+KYTOS_API = 'http://%s:8181/api/kytos' % CONTROLLER
 
 TIME_FMT = "%Y-%m-%dT%H:%M:%S+0000"
 
@@ -83,7 +83,7 @@ class TestE2EMaintenance:
         time.sleep(80)
 
         # switch 1 and 3 should have 3 flows, switch 2 should have only 1 flow
-        s1, s2, s3 = self.net.net.get( 's1', 's2', 's3' )
+        s1, s2, s3 = self.net.net.get('s1', 's2', 's3')
         flows_s1 = s1.dpctl('dump-flows')
         flows_s2 = s2.dpctl('dump-flows')
         flows_s3 = s3.dpctl('dump-flows')
@@ -99,14 +99,14 @@ class TestE2EMaintenance:
         # Make the final and most important test: connectivity
         # 1. create the vlans and setup the ip addresses
         # 2. try to ping each other
-        h11, h3 = self.net.net.get( 'h11', 'h3' )
+        h11, h3 = self.net.net.get('h11', 'h3')
         h11.cmd('ip link add link %s name vlan100 type vlan id 100' % (h11.intfNames()[0]))
         h11.cmd('ip link set up vlan100')
         h11.cmd('ip addr add 100.0.0.11/24 dev vlan100')
         h3.cmd('ip link add link %s name vlan100 type vlan id 100' % (h3.intfNames()[0]))
         h3.cmd('ip link set up vlan100')
         h3.cmd('ip addr add 100.0.0.2/24 dev vlan100')
-        result = h11.cmd( 'ping -c1 100.0.0.2' )
+        result = h11.cmd('ping -c1 100.0.0.2')
         assert ', 0% packet loss,' in result
 
         # wait more 60s to the MW to finish and check if the path returned to pass through sw2
@@ -114,10 +114,9 @@ class TestE2EMaintenance:
 
         flows_s2 = s2.dpctl('dump-flows')
         assert len(flows_s2.split('\r\n ')) == 3
-        result = h11.cmd( 'ping -c1 100.0.0.2' )
+        result = h11.cmd('ping -c1 100.0.0.2')
         assert ', 0% packet loss,' in result
 
         # clean up
         h11.cmd('ip link del vlan100')
         h3.cmd('ip link del vlan100')
-

--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -16,15 +16,16 @@ class TestE2EFlowManager:
         """
         # Start the controller setting an environment in
         # which all elements are disabled in a clean setting
-        self.net.start_controller(clean_config=True, enable_all=False)
+        self.net.start_controller(clean_config=True, enable_all=True)
         self.net.wait_switches_connect()
-        time.sleep(5)
+        time.sleep(10)
 
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER)
         cls.net.start()
         cls.net.wait_switches_connect()
+        time.sleep(10)
 
     @classmethod
     def teardown_class(cls):
@@ -33,8 +34,6 @@ class TestE2EFlowManager:
     def test_020_install_flow(self):
         """Test if, after kytos restart, a flow installed to a switch will
            still be installed."""
-        # self.net.restart_kytos_clean()
-        # time.sleep(5)
 
         payload = {
             "flows": [
@@ -78,8 +77,6 @@ class TestE2EFlowManager:
     def test_020_install_flows(self):
         """Test if, after kytos restart, a flow installed to all switches will
            still be installed."""
-        # self.net.restart_kytos_clean()
-        # time.sleep(5)
 
         payload = {
             "flows": [
@@ -124,8 +121,6 @@ class TestE2EFlowManager:
     def test_020_delete_flow(self):
         """Test if, after kytos restart, a flow deleted from a switch will
            still be deleted."""
-        # self.net.restart_kytos_clean()
-        # time.sleep(5)
 
         payload = {
             "flows": [
@@ -180,8 +175,6 @@ class TestE2EFlowManager:
     def test_020_delete_flows(self):
         """Test if, after kytos restart, a flow deleted from all switches will
            still be deleted."""
-        # self.net.restart_kytos_clean()
-        # time.sleep(5)
 
         payload = {
             "flows": [
@@ -291,8 +284,6 @@ class TestE2EFlowManager:
         self.modify_match(restart_kytos=True)
 
     def replace_action_flow(self, restart_kytos=False):
-        # self.net.restart_kytos_clean()
-        # time.sleep(5)
 
         payload = {
             "flows": [
@@ -355,8 +346,6 @@ class TestE2EFlowManager:
         self.replace_action_flow(restart_kytos=True)
 
     def add_action_flow(self, restart_kytos=False):
-        # self.net.restart_kytos_clean()
-        # time.sleep(5)
 
         payload = {
             "flows": [
@@ -412,8 +401,6 @@ class TestE2EFlowManager:
     def flow_another_table(self, restart_kytos=False):
         """Test if, after adding a flow in another table outside kytos, the 
             flow is removed."""
-        # self.net.restart_kytos_clean()
-        # time.sleep(5)
 
         s1 = self.net.net.get('s1')
         s1.dpctl('add-flow', 'table=2,in_port=1,actions=output:2')
@@ -436,8 +423,6 @@ class TestE2EFlowManager:
     def flow_table_0(self, restart_kytos=False):
         """Test if, after adding a flow in another table outside kytos, the
             flow is removed."""
-        # self.net.restart_kytos_clean()
-        # time.sleep(5)
 
         s1 = self.net.net.get('s1')
         s1.dpctl('add-flow', 'table=0,in_port=1,actions=output:2')

--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -31,7 +31,7 @@ class TestE2EFlowManager:
     def teardown_class(cls):
         cls.net.stop()
 
-    def test_020_install_flow(self):
+    def test_010_install_flow(self):
         """Test if, after kytos restart, a flow installed to a switch will
            still be installed."""
 
@@ -74,7 +74,7 @@ class TestE2EFlowManager:
         assert len(flows_s1.split('\r\n ')) == 2
         assert 'actions=output:"s1-eth2"' in flows_s1
 
-    def test_020_install_flows(self):
+    def test_015_install_flows(self):
         """Test if, after kytos restart, a flow installed to all switches will
            still be installed."""
 
@@ -172,7 +172,7 @@ class TestE2EFlowManager:
         assert len(flows_s1.split('\r\n ')) == 1
         assert 'actions=output:"s1-eth2"' not in flows_s1
 
-    def test_020_delete_flows(self):
+    def test_025_delete_flows(self):
         """Test if, after kytos restart, a flow deleted from all switches will
            still be deleted."""
 
@@ -277,10 +277,10 @@ class TestE2EFlowManager:
         assert len(flows_s1.split('\r\n ')) == 2
         assert 'in_port="s1-eth1' in flows_s1
 
-    def test_020_modify_match(self):
+    def test_030_modify_match(self):
         self.modify_match()
 
-    def test_020_modify_match_restarting(self):
+    def test_035_modify_match_restarting(self):
         self.modify_match(restart_kytos=True)
 
     def replace_action_flow(self, restart_kytos=False):
@@ -339,10 +339,10 @@ class TestE2EFlowManager:
         assert 'actions=output:"s1-eth3"' not in flows_s1
         assert 'in_port="s1-eth1' in flows_s1
 
-    def test_020_replace_action_flow(self):
+    def test_040_replace_action_flow(self):
         self.replace_action_flow()
 
-    def test_020_replace_action_flow_restarting(self):
+    def test_045_replace_action_flow_restarting(self):
         self.replace_action_flow(restart_kytos=True)
 
     def add_action_flow(self, restart_kytos=False):
@@ -392,10 +392,10 @@ class TestE2EFlowManager:
         assert 'actions=strip_vlan,' not in flows_s1
         assert 'actions=output:"s1-eth2' in flows_s1
 
-    def test_020_add_action_flow(self):
+    def test_050_add_action_flow(self):
         self.add_action_flow()
 
-    def test_020_add_action_flow_restarting(self):
+    def test_055_add_action_flow_restarting(self):
         self.add_action_flow(restart_kytos=True)
 
     def flow_another_table(self, restart_kytos=False):
@@ -414,10 +414,10 @@ class TestE2EFlowManager:
         flows_s1 = s1.dpctl('dump-flows')
         assert len(flows_s1.split('\r\n ')) == 1
 
-    def test_020_flow_another_table(self):
+    def test_060_flow_another_table(self):
         self.flow_another_table()
 
-    def test_020_flow_another_table_restarting(self):
+    def test_065_flow_another_table_restarting(self):
         self.flow_another_table(restart_kytos=True)
 
     def flow_table_0(self, restart_kytos=False):
@@ -437,8 +437,8 @@ class TestE2EFlowManager:
         flows_s1 = s1.dpctl('dump-flows')
         assert len(flows_s1.split('\r\n ')) == 1
 
-    def test_020_flow_table_0(self):
+    def test_070_flow_table_0(self):
         self.flow_table_0()
 
-    def test_020_flow_table_0_restarting(self):
+    def test_075_flow_table_0_restarting(self):
         self.flow_table_0(restart_kytos=True)

--- a/tests/test_e2e_21_flow_manager.py
+++ b/tests/test_e2e_21_flow_manager.py
@@ -19,13 +19,14 @@ class TestE2EFlowManager:
         # which all elements are disabled in a clean setting
         self.net.start_controller(clean_config=True, enable_all=False)
         self.net.wait_switches_connect()
-        time.sleep(5)
+        time.sleep(10)
 
     @classmethod
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER)
         cls.net.start()
         cls.net.wait_switches_connect()
+        time.sleep(10)
 
     @classmethod
     def teardown_class(cls):
@@ -38,23 +39,23 @@ class TestE2EFlowManager:
         payload = {
             "flows": [
                 {
-                "priority": 10,
-                "match": {
-                    "in_port": 1,
-                    "dl_vlan": 999
-                },
-                "actions": [
-                    {
-                    "action_type": "output",
-                    "port": 2
-                    }
-                ]
+                    "priority": 10,
+                    "match": {
+                        "in_port": 1,
+                        "dl_vlan": 999
+                    },
+                    "actions": [
+                        {
+                            "action_type": "output",
+                            "port": 2
+                        }
+                    ]
                 }
             ]
         }
 
         api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
-        response = requests.post(api_url, data=json.dumps(payload), 
+        response = requests.post(api_url, data=json.dumps(payload),
                                  headers={'Content-type': 'application/json'})
         assert response.status_code == 200
         data = response.json()
@@ -89,23 +90,23 @@ class TestE2EFlowManager:
         payload = {
             "flows": [
                 {
-                "priority": 10,
-                "match": {
-                    "in_port": 1,
-                    "dl_vlan": 999
-                },
-                "actions": [
-                    {
-                    "action_type": "output",
-                    "port": 2
-                    }
-                ]
+                    "priority": 10,
+                    "match": {
+                        "in_port": 1,
+                        "dl_vlan": 999
+                    },
+                    "actions": [
+                        {
+                            "action_type": "output",
+                            "port": 2
+                        }
+                    ]
                 }
             ]
         }
 
         api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
-        response = requests.post(api_url, data=json.dumps(payload), 
+        response = requests.post(api_url, data=json.dumps(payload),
                                  headers={'Content-type': 'application/json'})
         assert response.status_code == 200
         data = response.json()

--- a/tests/test_e2e_30_of_lldp.py
+++ b/tests/test_e2e_30_of_lldp.py
@@ -17,6 +17,8 @@ class TestE2EOfLLDP:
         cls.net = NetworkTest(CONTROLLER)
         cls.net.start()
         cls.net.restart_kytos_clean()
+        cls.net.wait_switches_connect()
+        time.sleep(10)
 
     @classmethod
     def teardown_class(cls):

--- a/tests/test_e2e_30_of_lldp.py
+++ b/tests/test_e2e_30_of_lldp.py
@@ -9,17 +9,17 @@ CONTROLLER = '127.0.0.1'
 KYTOS_API = 'http://%s:8181/api/kytos' % (CONTROLLER)
 
 
-class TestE2EOfLLDP(unittest.TestCase):
+class TestE2EOfLLDP:
     net = None
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER)
         cls.net.start()
         cls.net.restart_kytos_clean()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         cls.net.stop()
 
     def get_iface_stats_rx_pkt(self, host):

--- a/tests/test_e2e_30_of_lldp.py
+++ b/tests/test_e2e_30_of_lldp.py
@@ -1,12 +1,9 @@
-import unittest
 import requests
 from tests.helpers import NetworkTest
-import os
 import time
-import json
 
 CONTROLLER = '127.0.0.1'
-KYTOS_API = 'http://%s:8181/api/kytos' % (CONTROLLER)
+KYTOS_API = 'http://%s:8181/api/kytos' % CONTROLLER
 
 
 class TestE2EOfLLDP:
@@ -28,7 +25,8 @@ class TestE2EOfLLDP:
         rx_pkts = host.cmd("ip -s link show dev %s | grep RX: -A 1 | tail -n1 | awk '{print $2}'" % (host.intfNames()[0]))
         return int(rx_pkts.strip())
 
-    def disable_all_of_lldp(self):
+    @staticmethod
+    def disable_all_of_lldp():
         api_url = KYTOS_API + '/of_lldp/v1/interfaces/'
         response = requests.get(api_url)
         data = response.json()
@@ -50,9 +48,12 @@ class TestE2EOfLLDP:
         # s2 lo:  s2-eth1:h2-eth0 s2-eth2:s1-eth3 s2-eth3:s3-eth2
         # s3 lo:  s3-eth1:h3-eth0 s3-eth2:s2-eth3 s3-eth3:s1-eth4
         expected_interfaces = [
-                "00:00:00:00:00:00:00:01:1","00:00:00:00:00:00:00:01:2","00:00:00:00:00:00:00:01:3", "00:00:00:00:00:00:00:01:4", "00:00:00:00:00:00:00:01:4294967294",
-                "00:00:00:00:00:00:00:02:1","00:00:00:00:00:00:00:02:2","00:00:00:00:00:00:00:02:3", "00:00:00:00:00:00:00:02:4294967294",
-                "00:00:00:00:00:00:00:03:1","00:00:00:00:00:00:00:03:2","00:00:00:00:00:00:00:03:3", "00:00:00:00:00:00:00:03:4294967294"
+                "00:00:00:00:00:00:00:01:1", "00:00:00:00:00:00:00:01:2", "00:00:00:00:00:00:00:01:3",
+                "00:00:00:00:00:00:00:01:4", "00:00:00:00:00:00:00:01:4294967294",
+                "00:00:00:00:00:00:00:02:1", "00:00:00:00:00:00:00:02:2", "00:00:00:00:00:00:00:02:3",
+                "00:00:00:00:00:00:00:02:4294967294",
+                "00:00:00:00:00:00:00:03:1", "00:00:00:00:00:00:00:03:2", "00:00:00:00:00:00:00:03:3",
+                "00:00:00:00:00:00:00:03:4294967294"
         ]
         assert set(data["interfaces"]) == set(expected_interfaces)
 
@@ -60,18 +61,18 @@ class TestE2EOfLLDP:
         h11, h12, h2, h3 = self.net.net.get('h11', 'h12', 'h2', 'h3')
         rx_stats_h11 = self.get_iface_stats_rx_pkt(h11)
         rx_stats_h12 = self.get_iface_stats_rx_pkt(h12)
-        rx_stats_h2  = self.get_iface_stats_rx_pkt(h2)
-        rx_stats_h3  = self.get_iface_stats_rx_pkt(h3)
+        rx_stats_h2 = self.get_iface_stats_rx_pkt(h2)
+        rx_stats_h3 = self.get_iface_stats_rx_pkt(h3)
         time.sleep(10)
         rx_stats_h11_2 = self.get_iface_stats_rx_pkt(h11)
         rx_stats_h12_2 = self.get_iface_stats_rx_pkt(h12)
-        rx_stats_h2_2  = self.get_iface_stats_rx_pkt(h2)
-        rx_stats_h3_2  = self.get_iface_stats_rx_pkt(h3)
+        rx_stats_h2_2 = self.get_iface_stats_rx_pkt(h2)
+        rx_stats_h3_2 = self.get_iface_stats_rx_pkt(h3)
 
         assert rx_stats_h11_2 > rx_stats_h11 \
-                and rx_stats_h12_2 > rx_stats_h12 \
-                and rx_stats_h2_2 > rx_stats_h2 \
-                and rx_stats_h3_2 > rx_stats_h3
+            and rx_stats_h12_2 > rx_stats_h12 \
+            and rx_stats_h2_2 > rx_stats_h2 \
+            and rx_stats_h3_2 > rx_stats_h3
 
     def test_010_disable_of_lldp(self):
         """ Test if the disabling OF LLDP in an interface worked properly. """
@@ -102,18 +103,18 @@ class TestE2EOfLLDP:
         h11, h12, h2, h3 = self.net.net.get('h11', 'h12', 'h2', 'h3')
         rx_stats_h11 = self.get_iface_stats_rx_pkt(h11)
         rx_stats_h12 = self.get_iface_stats_rx_pkt(h12)
-        rx_stats_h2  = self.get_iface_stats_rx_pkt(h2)
-        rx_stats_h3  = self.get_iface_stats_rx_pkt(h3)
+        rx_stats_h2 = self.get_iface_stats_rx_pkt(h2)
+        rx_stats_h3 = self.get_iface_stats_rx_pkt(h3)
         time.sleep(10)
         rx_stats_h11_2 = self.get_iface_stats_rx_pkt(h11)
         rx_stats_h12_2 = self.get_iface_stats_rx_pkt(h12)
-        rx_stats_h2_2  = self.get_iface_stats_rx_pkt(h2)
-        rx_stats_h3_2  = self.get_iface_stats_rx_pkt(h3)
+        rx_stats_h2_2 = self.get_iface_stats_rx_pkt(h2)
+        rx_stats_h3_2 = self.get_iface_stats_rx_pkt(h3)
 
         assert rx_stats_h11_2 == rx_stats_h11 \
-                and rx_stats_h12_2 == rx_stats_h12 \
-                and rx_stats_h2_2 == rx_stats_h2 \
-                and rx_stats_h3_2 == rx_stats_h3
+            and rx_stats_h12_2 == rx_stats_h12 \
+            and rx_stats_h2_2 == rx_stats_h2 \
+            and rx_stats_h3_2 == rx_stats_h3
 
         # restart kytos and check if lldp remains disabled
         self.net.start_controller(clean_config=False)
@@ -129,7 +130,7 @@ class TestE2EOfLLDP:
         """ Test if enabling OF LLDP in an interface works properly. """
         self.net.restart_kytos_clean()
         time.sleep(5)
-        self.disable_all_of_lldp()
+        TestE2EOfLLDP.disable_all_of_lldp()
 
         payload = {
             "interfaces": [


### PR DESCRIPTION
It has been performed different task all over all the tests files, such as:
- Increasing the waiting time during the setup process
- Setting a Pytest environment with the setup_class & teardown_class approach
- Elimination of the Unittest relation
- Renaming methods to follow a logical and continuous sequence
- Cleaning up the code
- Following PEP8 convention