### PR TITLE
Implement the log rotation routine

### DIFF
--- a/tests/test_e2e_01_kytos_startup.py
+++ b/tests/test_e2e_01_kytos_startup.py
@@ -1,5 +1,5 @@
 import time
-
+import shutil
 import requests
 from tests.helpers import NetworkTest
 import re
@@ -31,6 +31,10 @@ class TestE2EKytosServer:
         cls.net = NetworkTest(CONTROLLER)
         cls.net.start()
         cls.net.wait_switches_connect()
+        # rotate logfile (copytruncate strategy)
+        logfile = '/var/log/syslog'
+        shutil.copy(logfile, logfile + '-' + time.strftime("%Y%m%d%H%M%S"))
+        open(logfile, 'w').close()
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
This PR implements the log rotation routine to avoid errors being accounted for from the previous execution.

The end-to-end tests, especially tests/test_e2e_01_kytos_startup.py, verify if by the end of the test there are some errors on Kytos log (/var/log/syslog). However, if previous execution left an error, they will be accounted for in the current test - leading to an invalid assertion failure.

