### PR TITLE
Apply flag enable_all in tests/test_e2e_21_flow_manager.py

### DIFF
--- a/tests/test_e2e_21_flow_manager.py
+++ b/tests/test_e2e_21_flow_manager.py
@@ -17,7 +17,7 @@ class TestE2EFlowManager:
         """
         # Start the controller setting an environment in
         # which all elements are disabled in a clean setting
-        self.net.start_controller(clean_config=True, enable_all=False)
+        self.net.start_controller(clean_config=True, enable_all=True)
         self.net.wait_switches_connect()
         time.sleep(5)
 


### PR DESCRIPTION
Flow manager tests (tests/test_e2e_21_flow_manager.py) expect that all the entities are enable, but they aren't by default. This PR fix this issue and make all entities enabled by default.