### PR TITLE
mef-eline tests

### DIFF
--- a/tests/test_e2e_12_mef_eline.py
+++ b/tests/test_e2e_12_mef_eline.py
@@ -260,12 +260,14 @@ class TestE2EMefEline:
         assert payload.get("frequency") == frequency
 
     def test_delete_circuit_id(self, circuit_id):
-        """ Test circuit creation and removal. """
+        """ Test circuit removal action. """
 
         # Delete the circuit
         api_url = KYTOS_API + '/mef_eline/v2/evc/' + circuit_id
         response = requests.delete(api_url)
         assert response.status_code == 200
+
+        time.sleep(2)
 
         # Verify circuit removal by
         # listing all the circuits stored
@@ -274,3 +276,10 @@ class TestE2EMefEline:
         assert response.status_code == 200
         data = response.json()
         assert data == {}
+
+        # Verify that the flow is not on the flow table
+        s1 = self.net.net.get('s1')
+        flows_s1 = s1.dpctl('dump-flows')
+        # Each switch had 3 flows: 01 for LLDP + 02 for the EVC (ingress + egress)
+        # at this point the flow number should be reduced to 1
+        assert len(flows_s1.split('\r\n ')) == 1

--- a/tests/test_e2e_12_mef_eline.py
+++ b/tests/test_e2e_12_mef_eline.py
@@ -262,16 +262,6 @@ class TestE2EMefEline:
     def test_delete_circuit_id(self, circuit_id):
         """ Test circuit creation and removal. """
 
-        # Verify circuit creation by
-        # listing all the circuits stored
-        api_url = KYTOS_API + '/mef_eline/v2/evc'
-        response = requests.get(api_url)
-        assert response.status_code == 200
-        data = response.json()
-        key = next(iter(data))
-        assert data is not {}
-        assert data[key].get("uni_a")["interface_id"] == "00:00:00:00:00:00:00:01:1"
-
         # Delete the circuit
         api_url = KYTOS_API + '/mef_eline/v2/evc/' + circuit_id
         response = requests.delete(api_url)

--- a/tests/test_e2e_12_mef_eline.py
+++ b/tests/test_e2e_12_mef_eline.py
@@ -241,3 +241,27 @@ class TestE2EMefEline:
 
         frequency = json.get("circuit_scheduler")[0].get("frequency")
         assert payload.get("frequency") == frequency
+
+    def test_delete_circuit_id(self, circuit_id):
+        """ Test circuit creation and removal. """
+
+        # Verify the circuit creation
+        api_url = KYTOS_API + '/mef_eline/v2/evc'
+        response = requests.get(api_url)
+        assert response.status_code == 200
+        data = response.json()
+        key = next(iter(data))
+        assert data is not {}
+        assert data[key].get("uni_a")["interface_id"] == "00:00:00:00:00:00:00:01:1"
+
+        # Delete the circuit
+        api_url = KYTOS_API + '/mef_eline/v2/evc/' + circuit_id
+        response = requests.delete(api_url)
+        assert response.status_code == 200
+
+        # Verify circuit removal
+        api_url = KYTOS_API + '/mef_eline/v2/evc'
+        response = requests.get(api_url)
+        assert response.status_code == 200
+        data = response.json()
+        assert data == {}

--- a/tests/test_e2e_12_mef_eline.py
+++ b/tests/test_e2e_12_mef_eline.py
@@ -170,10 +170,19 @@ class TestE2EMefEline:
             }
         }
 
-        # create circuit schedule
+        # Create circuit schedule
         api_url = KYTOS_API + '/mef_eline/v2/evc/schedule'
         response = requests.post(api_url, json=payload)
         assert response.status_code == 201
+
+        # Verify the list of schedules
+        api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/'
+        response = requests.get(api_url)
+        assert response.status_code == 200
+
+        data = response.json()[0]
+        assert data.get("circuit_id") == circuit_id
+        assert len(response.json()) == 1
 
         # Recover schedule id created
         api_url = KYTOS_API + '/mef_eline/v2/evc/' + circuit_id
@@ -181,7 +190,7 @@ class TestE2EMefEline:
         json = response.json()
         schedule_id = json.get("circuit_scheduler")[0].get("id")
 
-        # delete circuit schedule
+        # Delete circuit schedule
         api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/' + schedule_id
         response = requests.delete(api_url)
         assert response.status_code == 200
@@ -190,6 +199,14 @@ class TestE2EMefEline:
         api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/' + schedule_id
         response = requests.get(api_url)
         assert response.status_code == 405
+
+        # Verify the list of schedules
+        api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/'
+        response = requests.get(api_url)
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data == []
 
     def test_patch_schedule(self, disabled_circuit_id):
         """ Test to modify a scheduler and enable a circuit 
@@ -245,7 +262,8 @@ class TestE2EMefEline:
     def test_delete_circuit_id(self, circuit_id):
         """ Test circuit creation and removal. """
 
-        # Verify the circuit creation
+        # Verify circuit creation by
+        # listing all the circuits stored
         api_url = KYTOS_API + '/mef_eline/v2/evc'
         response = requests.get(api_url)
         assert response.status_code == 200
@@ -259,7 +277,8 @@ class TestE2EMefEline:
         response = requests.delete(api_url)
         assert response.status_code == 200
 
-        # Verify circuit removal
+        # Verify circuit removal by
+        # listing all the circuits stored
         api_url = KYTOS_API + '/mef_eline/v2/evc'
         response = requests.get(api_url)
         assert response.status_code == 200

--- a/tests/test_e2e_12_mef_eline.py
+++ b/tests/test_e2e_12_mef_eline.py
@@ -259,6 +259,24 @@ class TestE2EMefEline:
         frequency = json.get("circuit_scheduler")[0].get("frequency")
         assert payload.get("frequency") == frequency
 
+    def test_list_circuits(self, circuit_id):
+        """ Test circuit listing action. """
+
+        # List all the circuits stored
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        response = requests.get(api_url)
+        assert response.status_code == 200
+        data = response.json()
+        key = next(iter(data))
+        assert data is not {}
+        assert data[key].get("uni_a")["interface_id"] == "00:00:00:00:00:00:00:01:1"
+
+        # Verify that the flow is in the flow table
+        s1 = self.net.net.get('s1')
+        flows_s1 = s1.dpctl('dump-flows')
+        # Each switch had 3 flows: 01 for LLDP + 02 for the EVC (ingress + egress)
+        assert len(flows_s1.split('\r\n ')) == 3
+
     def test_delete_circuit_id(self, circuit_id):
         """ Test circuit removal action. """
 
@@ -271,13 +289,13 @@ class TestE2EMefEline:
 
         # Verify circuit removal by
         # listing all the circuits stored
-        api_url = KYTOS_API + '/mef_eline/v2/evc'
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.get(api_url)
         assert response.status_code == 200
         data = response.json()
         assert data == {}
 
-        # Verify that the flow is not on the flow table
+        # Verify that the flow is not in the flow table
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
         # Each switch had 3 flows: 01 for LLDP + 02 for the EVC (ingress + egress)


### PR DESCRIPTION
It includes new tests to cover the missing API calls in the mef_eline NApp, such as:
- /v2/evc/ on GET
- /v2/evc/{circuit_id} on DELETE, and
- /v2/evc/schedule/ on GET (it was used /mef_eline/v2/evc/schedule/' + schedule_id on GET many times)