### PR TITLE
New tests related to Topology Napp and some minor changes

### DIFF
--- a/tests/test_e2e_01_kytos_startup.py
+++ b/tests/test_e2e_01_kytos_startup.py
@@ -31,7 +31,7 @@ class TestE2EKytosServer:
         cls.net = NetworkTest(CONTROLLER)
         cls.net.start()
         cls.net.wait_switches_connect()
-        # rotate logfile (copytruncate strategy)
+        # rotate logfile (copy/truncate strategy)
         logfile = '/var/log/syslog'
         shutil.copy(logfile, logfile + '-' + time.strftime("%Y%m%d%H%M%S"))
         open(logfile, 'w').close()

--- a/tests/test_e2e_05_topology.py
+++ b/tests/test_e2e_05_topology.py
@@ -264,45 +264,7 @@ class TestE2ETopology:
         data = response.json()
         assert data['interfaces'][interface_id]['enabled'] is True
 
-    def test_060_enabling_all_interfaces_on_a_switch_persistent(self):
-        """
-        Test /api/kytos/topology/v3/interfaces/switch/{dpid}/enable on POST
-        supported by
-            /api/kytos/topology/v3/switches on GET
-        """
-
-        switch_id = "00:00:00:00:00:00:00:01"
-
-        # Make sure all the interfaces belonging to the target switch are disabled
-        api_url = KYTOS_API + '/topology/v3/switches'
-        response = requests.get(api_url)
-        data = response.json()
-
-        for interface in data['switches'][switch_id]['interfaces']:
-            assert data['switches'][switch_id]['interfaces'][interface]['enabled'] is False
-
-        # Enabling all the interfaces
-        api_url = KYTOS_API + '/topology/v3/interfaces/switch/%s/enable' % switch_id
-        response = requests.post(api_url)
-        assert response.status_code == 200
-
-        # Start the controller setting an environment in which the setting is
-        # preserved (persistence) and avoid the default enabling of all elements
-        self.net.start_controller(clean_config=False, enable_all=False)
-        self.net.wait_switches_connect()
-
-        # Wait 10s to kytos execute LLDP
-        time.sleep(10)
-
-        # Make sure all the interfaces belonging to the target switch are enabled
-        api_url = KYTOS_API + '/topology/v3/switches'
-        response = requests.get(api_url)
-        data = response.json()
-
-        for interface in data['switches'][switch_id]['interfaces']:
-            assert data['switches'][switch_id]['interfaces'][interface]['enabled'] is True
-
-    def test_065_disabling_all_interfaces_on_a_switch_persistent(self):
+    def test_060_enabling_and_disabling_all_interfaces_on_a_switch_persistent(self):
         """
         Test /api/kytos/topology/v3/interfaces/switch/{dpid}/disable on POST
         supported by

--- a/tests/test_e2e_05_topology.py
+++ b/tests/test_e2e_05_topology.py
@@ -31,9 +31,25 @@ class TestE2ETopology:
     def teardown_class(cls):
         cls.net.stop()
 
-    def test_010_list_switches(self):
+    def test_005_list_topology(self):
         """
         Test /api/kytos/topology/v3/ on GET
+        """
+        api_url = KYTOS_API + '/topology/v3/'
+        response = requests.get(api_url)
+        data = response.json()
+
+        assert response.status_code == 200
+        assert 'topology' in data
+        assert 'switches' in data['topology']
+        assert len(data['topology']['switches']) == 3
+        assert '00:00:00:00:00:00:00:01' in data['topology']['switches']
+        assert '00:00:00:00:00:00:00:02' in data['topology']['switches']
+        assert '00:00:00:00:00:00:00:03' in data['topology']['switches']
+
+    def test_010_list_switches(self):
+        """
+        Test /api/kytos/topology/v3/switches on GET
         """
         api_url = KYTOS_API + '/topology/v3/switches'
         response = requests.get(api_url)

--- a/tests/test_e2e_05_topology.py
+++ b/tests/test_e2e_05_topology.py
@@ -39,13 +39,31 @@ class TestE2ETopology:
         response = requests.get(api_url)
         data = response.json()
 
+        topology = {'00:00:00:00:00:00:00:01':
+                        ['00:00:00:00:00:00:00:01:1', '00:00:00:00:00:00:00:01:2', '00:00:00:00:00:00:00:01:3',
+                         '00:00:00:00:00:00:00:01:4', '00:00:00:00:00:00:00:01:4294967294'],
+                    '00:00:00:00:00:00:00:02':
+                        ['00:00:00:00:00:00:00:02:1', '00:00:00:00:00:00:00:02:2', '00:00:00:00:00:00:00:02:3',
+                         '00:00:00:00:00:00:00:02:4294967294'],
+                    '00:00:00:00:00:00:00:03':
+                        ['00:00:00:00:00:00:00:03:1', '00:00:00:00:00:00:00:03:2', '00:00:00:00:00:00:00:03:3',
+                         '00:00:00:00:00:00:00:03:4294967294'],
+                    }
+
         assert response.status_code == 200
         assert 'topology' in data
         assert 'switches' in data['topology']
         assert len(data['topology']['switches']) == 3
-        assert '00:00:00:00:00:00:00:01' in data['topology']['switches']
-        assert '00:00:00:00:00:00:00:02' in data['topology']['switches']
-        assert '00:00:00:00:00:00:00:03' in data['topology']['switches']
+
+        for switch in data['topology']['switches']:
+            # switches validation
+            assert switch in topology
+            # interfaces validation
+            assert topology[switch].sort() == \
+                   list(map(str, data['topology']['switches'][str(switch)]['interfaces'])).sort()
+            # links validation
+            for link in data['topology']['switches'][str(switch)]['interfaces']:
+                assert 'link' in data['topology']['switches'][str(switch)]['interfaces'][link]
 
     def test_010_list_switches(self):
         """

--- a/tests/test_e2e_05_topology.py
+++ b/tests/test_e2e_05_topology.py
@@ -284,6 +284,65 @@ class TestE2ETopology:
         for interface in data['switches'][switch_id]['interfaces']:
             assert data['switches'][switch_id]['interfaces'][interface]['enabled'] is True
 
+    def test_065_disabling_all_interfaces_on_a_switch_persistent(self):
+        """
+        Test /api/kytos/topology/v3/interfaces/switch/{dpid}/disable on POST
+        supported by
+            /api/kytos/topology/v3/switches on GET
+        """
+
+        switch_id = "00:00:00:00:00:00:00:01"
+
+        # Make sure all the interfaces belonging to the target switch are disabled
+        api_url = KYTOS_API + '/topology/v3/switches'
+        response = requests.get(api_url)
+        data = response.json()
+
+        for interface in data['switches'][switch_id]['interfaces']:
+            assert data['switches'][switch_id]['interfaces'][interface]['enabled'] is False
+
+        # Enabling all the interfaces
+        api_url = KYTOS_API + '/topology/v3/interfaces/switch/%s/enable' % switch_id
+        response = requests.post(api_url)
+        assert response.status_code == 200
+
+        # Start the controller setting an environment in which the setting is
+        # preserved (persistence) and avoid the default enabling of all elements
+        self.net.start_controller(clean_config=False, enable_all=False)
+        self.net.wait_switches_connect()
+
+        # Wait 20s to kytos execute LLDP
+        time.sleep(20)
+
+        # Make sure all the interfaces belonging to the target switch are enabled
+        api_url = KYTOS_API + '/topology/v3/switches'
+        response = requests.get(api_url)
+        data = response.json()
+
+        for interface in data['switches'][switch_id]['interfaces']:
+            assert data['switches'][switch_id]['interfaces'][interface]['enabled'] is True
+
+        # Disabling all the interfaces
+        api_url = KYTOS_API + '/topology/v3/interfaces/switch/%s/disable' % switch_id
+        response = requests.post(api_url)
+        assert response.status_code == 200
+
+        # Start the controller setting an environment in which the setting is
+        # preserved (persistence) and avoid the default enabling of all elements
+        self.net.start_controller(clean_config=False, enable_all=False)
+        self.net.wait_switches_connect()
+
+        # Wait 10s to kytos execute LLDP
+        time.sleep(10)
+
+        # Make sure all the interfaces belonging to the target switch are enabled
+        api_url = KYTOS_API + '/topology/v3/switches'
+        response = requests.get(api_url)
+        data = response.json()
+
+        for interface in data['switches'][switch_id]['interfaces']:
+            assert data['switches'][switch_id]['interfaces'][interface]['enabled'] is False
+
     def test_070_disabling_interface_persistent(self):
         """
         Test /api/kytos/topology/v3/interfaces/{interface_id}/disable on POST

--- a/tests/test_e2e_12_mef_eline.py
+++ b/tests/test_e2e_12_mef_eline.py
@@ -285,7 +285,7 @@ class TestE2EMefEline:
         response = requests.delete(api_url)
         assert response.status_code == 200
 
-        time.sleep(2)
+        time.sleep(10)
 
         # Verify circuit removal by
         # listing all the circuits stored


### PR DESCRIPTION
This PR includes two new tests relative to the Topology NApp to cover all the API calls.
The new implementations include:
- Implementation of new tests to verify the disabling process of all the interfaces on a switch as a persistent procedure.
API call /api/kytos/topology/v3/interfaces/switch/{dpid}/disable on Post
- Implementation of new tests to verify the API call '/topology/v3/' on Get

It also includes a minor modification on the method test_delete_circuit_id relative to the mef_eline NApp, in which the sleep time is increased to guarantee a proper response after deleting a circuit.

Some minor changes (code cosmetic related) are also included.