### PR TITLE
Fix mef_eline test to reuse the same vlan_id

### DIFF
--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -415,10 +415,9 @@ class TestE2EMefEline:
         evc1 = data['circuit_id']
         time.sleep(20)
 
-        # disable the circuit
-        payload = {"enable": False}
+        # Delete the circuit
         api_url += evc1
-        response = requests.patch(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
+        response = requests.delete(api_url)
         assert response.status_code == 200
         time.sleep(20)
 


### PR DESCRIPTION
The test is failing with the following error:
```
_______________________________ TestE2EMefEline.test_045_create_circuit_reusing_same_vlanid_from_previous_evc ________________________________

self = <tests.test_e2e_10_mef_eline.TestE2EMefEline instance at 0x7fb1d91bc2d8>

    def test_045_create_circuit_reusing_same_vlanid_from_previous_evc(self):
        payload = {
            "name": "Vlan125_Test_evc1",
            "enabled": True,
            "dynamic_backup_path": True,
            "uni_a": {
                "interface_id": "00:00:00:00:00:00:00:01:1",
                "tag": {"tag_type": 1, "value": 125}
            },
            "uni_z": {
                "interface_id": "00:00:00:00:00:00:00:02:1",
                "tag": {"tag_type": 1, "value": 125}
            }
        }
        api_url = KYTOS_API + '/mef_eline/v2/evc/'
        response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
        assert response.status_code == 201
        data = response.json()
        assert 'circuit_id' in data
        evc1 = data['circuit_id']
        time.sleep(5)

        # disable the circuit
        payload = {"enable": False}
        api_url += evc1
        response = requests.patch(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
        assert response.status_code == 200
        time.sleep(5)

        # try to reuse the vlan id
        payload = {
            "name": "Vlan125_Test_evc2",
            "enabled": True,
            "dynamic_backup_path": True,
            "uni_a": {
                "interface_id": "00:00:00:00:00:00:00:01:1",
                "tag": {"tag_type": 1, "value": 125}
            },
            "uni_z": {
                "interface_id": "00:00:00:00:00:00:00:02:1",
                "tag": {"tag_type": 1, "value": 125}
            }
        }
        api_url = KYTOS_API + '/mef_eline/v2/evc/'
        response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
>       assert response.status_code == 201
E       assert 409 == 201
E        +  where 409 = <Response [409]>.status_code

tests/test_e2e_10_mef_eline.py:441: AssertionError
```

This happens because mef_eline does not allow to reuse of the same vlan_id of a disabled circuit.. only for the archived EVC (or  'deleted EVC' if you will)