### PR TITLE
Adjust topology names and make them compatible with mn

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -33,7 +33,7 @@ class RingTopo( Topo ):
         self.addLink( s2, s3 )
         self.addLink( s3, s1 )
 
-class DanielaTopo( Topo ):
+class Ring4Topo( Topo ):
     """Create a network from semi-scratch with multiple controllers."""
     def build(self):
         #("*** Creating switches\n")
@@ -60,25 +60,23 @@ class DanielaTopo( Topo ):
         self.addLink(s3, s4)
         self.addLink(s4, s1)
 
-class TopologyFactory():
-    def create(self, type):
-        if type == "RingTopo":
-            return RingTopo()
-        elif type == "DanielaTopo":
-            return DanielaTopo()
+# you can run any of the topologies above by doing:
+#   mn --custom tests/helpers.py --topo ring --controller=remote,ip=127.0.0.1
+topos = {
+    'ring': ( lambda: RingTopo() ),
+    'ring4': ( lambda: Ring4Topo() ),
+}
 
 class NetworkTest():
-    def __init__(self, controller_ip, topo_name='RingTopo'):
+    def __init__(self, controller_ip, topo_name='ring'):
         # Create an instance of our topology
         mininet.clean.cleanup()
-        factory = TopologyFactory()
-        topo = factory.create(topo_name)
 
         # Create a network based on the topology using OVS and controlled by
         # a remote controller.
         patch('mininet.util.fixLimits', side_effect=None)
         self.net = Mininet(
-            topo=topo,
+            topo=topos.get(topo_name, ( lambda : RingTopo()))(),
             controller=lambda name: RemoteController(
                                         name, ip=controller_ip, port=6653),
             switch=OVSSwitch,

--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -415,10 +415,9 @@ class TestE2EMefEline:
         evc1 = data['circuit_id']
         time.sleep(20)
 
-        # disable the circuit
-        payload = {"enable": False}
+        # Delete the circuit
         api_url += evc1
-        response = requests.patch(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
+        response = requests.delete(api_url)
         assert response.status_code == 200
         time.sleep(20)
 

--- a/tests/test_e2e_11_mef_eline.py
+++ b/tests/test_e2e_11_mef_eline.py
@@ -14,7 +14,7 @@ class TestE2EMefEline(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.net = NetworkTest(CONTROLLER, topo_name='DanielaTopo')
+        cls.net = NetworkTest(CONTROLLER, topo_name='ring4')
         cls.net.start()
         cls.net.restart_kytos_clean()
 


### PR DESCRIPTION
This PR accomplishes two minor changes:
- Adjusting the topology names (DanielaTopo -> Ring4)
- create a dict of topology names to make them compatible with Mininet command line tool (mn):
```
mn --custom tests/helpers.py --topo ring --controller=remote,ip=127.0.0.1
```