### PR TITLE
fix errors on flow_manager and of_lldp end-to-end-tests

### DIFF
--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -65,7 +65,8 @@ class TestE2EFlowManager:
         time.sleep(10)
 
         # restart controller keeping configuration
-        self.net.start_controller(del_flows=True)
+        self.net.start_controller(enable_all=True, del_flows=True)
+        self.net.wait_switches_connect()
 
         time.sleep(10)
 
@@ -108,7 +109,8 @@ class TestE2EFlowManager:
         time.sleep(10)
 
         # restart controller keeping configuration
-        self.net.start_controller(del_flows=True)
+        self.net.start_controller(enable_all=True, del_flows=True)
+        self.net.wait_switches_connect()
 
         time.sleep(10)
 
@@ -163,7 +165,8 @@ class TestE2EFlowManager:
         time.sleep(10)
 
         # restart controller keeping configuration
-        self.net.start_controller(del_flows=True)
+        self.net.start_controller(enable_all=True, del_flows=True)
+        self.net.wait_switches_connect()
 
         time.sleep(10)
 
@@ -217,7 +220,8 @@ class TestE2EFlowManager:
         time.sleep(10)
 
         # restart controller keeping configuration
-        self.net.start_controller(del_flows=True)
+        self.net.start_controller(enable_all=True, del_flows=True)
+        self.net.wait_switches_connect()
 
         time.sleep(10)
 
@@ -268,7 +272,8 @@ class TestE2EFlowManager:
                              'dl_vlan=324,actions=output:1')
         if restart_kytos:
             # restart controller keeping configuration
-            self.net.start_controller()
+            self.net.start_controller(enable_all=True)
+            self.net.wait_switches_connect()
 
         time.sleep(10)
 
@@ -328,7 +333,8 @@ class TestE2EFlowManager:
 
         if restart_kytos:
             # restart controller keeping configuration
-            self.net.start_controller()
+            self.net.start_controller(enable_all=True)
+            self.net.wait_switches_connect()
 
         time.sleep(10)
 
@@ -383,7 +389,8 @@ class TestE2EFlowManager:
 
         if restart_kytos:
             # restart controller keeping configuration
-            self.net.start_controller()
+            self.net.start_controller(enable_all=True)
+            self.net.wait_switches_connect()
 
         time.sleep(10)
 
@@ -406,7 +413,8 @@ class TestE2EFlowManager:
         s1.dpctl('add-flow', 'table=2,in_port=1,actions=output:2')
         if restart_kytos:
             # restart controller keeping configuration
-            self.net.start_controller()
+            self.net.start_controller(enable_all=True)
+            self.net.wait_switches_connect()
 
         time.sleep(10)
 
@@ -429,7 +437,8 @@ class TestE2EFlowManager:
 
         if restart_kytos:
             # restart controller keeping configuration
-            self.net.start_controller()
+            self.net.start_controller(enable_all=True)
+            self.net.wait_switches_connect()
 
         time.sleep(10)
 

--- a/tests/test_e2e_30_of_lldp.py
+++ b/tests/test_e2e_30_of_lldp.py
@@ -25,6 +25,15 @@ class TestE2EOfLLDP:
         rx_pkts = host.cmd("ip -s link show dev %s | grep RX: -A 1 | tail -n1 | awk '{print $2}'" % (host.intfNames()[0]))
         return int(rx_pkts.strip())
 
+    def enable_all_interfaces(self):
+        api_url = KYTOS_API + '/topology/v3/switches/'
+        response = requests.get(api_url)
+        data = response.json()
+        switches = data.get("switches", {})
+        for sw in switches.keys():
+            response = requests.post(KYTOS_API + '/topology/v3/interfaces/switch/%s/enable' % sw)
+            assert response.status_code == 200
+
     @staticmethod
     def disable_all_of_lldp():
         api_url = KYTOS_API + '/of_lldp/v1/interfaces/'
@@ -132,6 +141,7 @@ class TestE2EOfLLDP:
         """ Test if enabling OF LLDP in an interface works properly. """
         self.net.restart_kytos_clean()
         time.sleep(5)
+        self.enable_all_interfaces()
         TestE2EOfLLDP.disable_all_of_lldp()
 
         payload = {

--- a/tests/test_e2e_30_of_lldp.py
+++ b/tests/test_e2e_30_of_lldp.py
@@ -32,7 +32,6 @@ class TestE2EOfLLDP:
         switches = data.get("switches", {})
         for sw in switches.keys():
             response = requests.post(KYTOS_API + '/topology/v3/interfaces/switch/%s/enable' % sw)
-            assert response.status_code == 200
 
     @staticmethod
     def disable_all_of_lldp():
@@ -85,8 +84,10 @@ class TestE2EOfLLDP:
 
     def test_010_disable_of_lldp(self):
         """ Test if the disabling OF LLDP in an interface worked properly. """
-        self.net.restart_kytos_clean()
+        self.net.start_controller(clean_config=True, enable_all=False)
+        self.net.wait_switches_connect()
         time.sleep(5)
+        self.enable_all_interfaces()
 
         # disabling all the UNI interfaces
         payload = {
@@ -128,7 +129,7 @@ class TestE2EOfLLDP:
             and rx_stats_h3_2 == rx_stats_h3
 
         # restart kytos and check if lldp remains disabled
-        self.net.start_controller(clean_config=False)
+        self.net.start_controller(clean_config=False, enable_all=False)
         self.net.wait_switches_connect()
         time.sleep(5)
 

--- a/tests/test_e2e_30_of_lldp.py
+++ b/tests/test_e2e_30_of_lldp.py
@@ -77,6 +77,8 @@ class TestE2EOfLLDP:
     def test_010_disable_of_lldp(self):
         """ Test if the disabling OF LLDP in an interface worked properly. """
         self.net.restart_kytos_clean()
+        time.sleep(5)
+
         # disabling all the UNI interfaces
         payload = {
             "interfaces": [
@@ -170,13 +172,15 @@ class TestE2EOfLLDP:
     def test_030_change_polling_interval(self):
         """ Test if changing the polling interval works works properly. """
         self.net.restart_kytos_clean()
+        time.sleep(5)
 
+        default_polling_time = 3
         api_url = KYTOS_API + '/of_lldp/v1/polling_time'
         response = requests.get(api_url)
         assert response.status_code == 200
         data = response.json()
         assert "polling_time" in data
-        assert data["polling_time"] == 3
+        assert data["polling_time"] == default_polling_time
 
         h11 = self.net.net.get('h11')
         rx_stats_h11 = self.get_iface_stats_rx_pkt(h11)
@@ -194,6 +198,9 @@ class TestE2EOfLLDP:
         response = requests.get(api_url)
         data = response.json()
         assert data["polling_time"] == 1
+
+        # wait a few seconds to let the last polling time schedule finish
+        time.sleep(default_polling_time)
 
         rx_stats_h11 = self.get_iface_stats_rx_pkt(h11)
         time.sleep(lldp_wait)

--- a/tests/test_e2e_30_of_lldp.py
+++ b/tests/test_e2e_30_of_lldp.py
@@ -139,7 +139,8 @@ class TestE2EOfLLDP:
 
     def test_020_enable_of_lldp(self):
         """ Test if enabling OF LLDP in an interface works properly. """
-        self.net.restart_kytos_clean()
+        self.net.start_controller(clean_config=True, enable_all=False)
+        self.net.wait_switches_connect()
         time.sleep(5)
         self.enable_all_interfaces()
         TestE2EOfLLDP.disable_all_of_lldp()

--- a/tests/test_e2e_30_of_lldp.py
+++ b/tests/test_e2e_30_of_lldp.py
@@ -171,7 +171,7 @@ class TestE2EOfLLDP:
         assert rx_stats_h11_2 > rx_stats_h11
 
         # restart kytos and check if lldp remains disabled
-        self.net.start_controller(clean_config=False)
+        self.net.start_controller(clean_config=False, enable_all=False)
         self.net.wait_switches_connect()
         time.sleep(5)
 


### PR DESCRIPTION
- Flow_manager e2e tests do not use the enable_all=True option when restarting the controller, which makes many tests to fail
- Of_lldp e2e tests do not consider the last scheduled LLDP event using the old polling time, which makes the test to fail eventually

Examples of failures:
```
# python -m pytest tests/
============================================================ test session starts =============================================================
platform linux2 -- Python 2.7.16, pytest-3.10.1, py-1.7.0, pluggy-0.8.0
rootdir: /kytos-end-to-end-tests, inifile:
plugins: timeout-1.3.3
collected 61 items

tests/test_e2e_01_kytos_startup.py ..                                                                                                  [  3%]
tests/test_e2e_05_topology.py .................                                                                                        [ 31%]
tests/test_e2e_10_mef_eline.py ............                                                                                            [ 50%]
tests/test_e2e_11_mef_eline.py ..                                                                                                      [ 54%]
tests/test_e2e_12_mef_eline.py ......                                                                                                  [ 63%]
tests/test_e2e_15_maintenance.py .F                                                                                                    [ 67%]
tests/test_e2e_20_flow_manager.py FF...F.F.F.F.F                                                                                       [ 90%]
tests/test_e2e_21_flow_manager.py ..                                                                                                   [ 93%]
tests/test_e2e_30_of_lldp.py ...F                                                                                                      [100%]

================================================================== FAILURES ==================================================================
__________________________________________________ TestE2EFlowManager.test_010_install_flow __________________________________________________

self = <tests.test_e2e_20_flow_manager.TestE2EFlowManager instance at 0x7f5bff77ff80>

    def test_010_install_flow(self):
        """Test if, after kytos restart, a flow installed to a switch will
           still be installed."""

        payload = {
            "flows": [
                {
                    "priority": 10,
                    "idle_timeout": 360,
                    "hard_timeout": 1200,
                    "match": {
                        "in_port": 1
                    },
                    "actions": [
                        {
                            "action_type": "output",
                            "port": 2
                        }
                    ]
                }
            ]
        }

        api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
        response = requests.post(api_url, data=json.dumps(payload),
                                 headers={'Content-type': 'application/json'})
        assert response.status_code == 200
        data = response.json()
        assert 'FlowMod Messages Sent' in data['response']

        # wait for the flow to be installed
        time.sleep(10)

        # restart controller keeping configuration
        self.net.start_controller(del_flows=True)

        time.sleep(10)

        s1 = self.net.net.get('s1')
        flows_s1 = s1.dpctl('dump-flows')
>       assert len(flows_s1.split('\r\n ')) == 2
E       AssertionError: assert 1 == 2
E        +  where 1 = len([''])
E        +    where [''] = <built-in method split of str object at 0x7f5c00bb7508>('\r\n ')
E        +      where <built-in method split of str object at 0x7f5c00bb7508> = ''.split

tests/test_e2e_20_flow_manager.py:74: AssertionError
_________________________________________________ TestE2EFlowManager.test_015_install_flows __________________________________________________

self = <tests.test_e2e_20_flow_manager.TestE2EFlowManager instance at 0x7f5bff7f1fc8>

    def test_015_install_flows(self):
        """Test if, after kytos restart, a flow installed to all switches will
           still be installed."""

        payload = {
            "flows": [
                {
                    "priority": 10,
                    "idle_timeout": 360,
                    "hard_timeout": 1200,
                    "match": {
                        "in_port": 1
                    },
                    "actions": [
                        {
                            "action_type": "output",
                            "port": 2
                        }
                    ]
                }
            ]
        }

        api_url = KYTOS_API + '/flow_manager/v2/flows'
        response = requests.post(api_url, data=json.dumps(payload),
                                 headers={'Content-type': 'application/json'})
        assert response.status_code == 200
        data = response.json()
        assert 'FlowMod Messages Sent' in data['response']

        # wait for the flow to be installed
        time.sleep(10)

        # restart controller keeping configuration
        self.net.start_controller(del_flows=True)

        time.sleep(10)

        for sw_name in ['s1', 's2', 's3']:
            sw = self.net.net.get(sw_name)
            flows_sw = sw.dpctl('dump-flows')
>           assert len(flows_sw.split('\r\n ')) == 2
E           AssertionError: assert 1 == 2
E            +  where 1 = len([''])
E            +    where [''] = <built-in method split of str object at 0x7f5c00bb7508>('\r\n ')
E            +      where <built-in method split of str object at 0x7f5c00bb7508> = ''.split

tests/test_e2e_20_flow_manager.py:118: AssertionError
____________________________________________ TestE2EFlowManager.test_035_modify_match_restarting _____________________________________________

self = <tests.test_e2e_20_flow_manager.TestE2EFlowManager instance at 0x7f5bff807248>

    def test_035_modify_match_restarting(self):
>       self.modify_match(restart_kytos=True)

tests/test_e2e_20_flow_manager.py:284:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <tests.test_e2e_20_flow_manager.TestE2EFlowManager instance at 0x7f5bff807248>, restart_kytos = True

    def modify_match(self, restart_kytos=False):
        """Test if after a match is modified outside kytos, the original
           flow is restored."""
        # self.net.restart_kytos_clean()
        # time.sleep(10)

        payload = {
            "flows": [
                {
                    "priority": 10,
                    "idle_timeout": 360,
                    "hard_timeout": 1200,
                    "match": {
                        "in_port": 1
                    },
                    "actions": [
                        {
                            "action_type": "output",
                            "port": 2
                        }
                    ]
                }
            ]
        }

        api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
        response = requests.post(api_url, data=json.dumps(payload),
                                 headers={'Content-type': 'application/json'})
        assert response.status_code == 200
        data = response.json()
        assert 'FlowMod Messages Sent' in data['response']

        # wait for the flow to be installed
        time.sleep(10)

        s1 = self.net.net.get('s1')
        s1.dpctl('del-flows', 'in_port=1')
        s1.dpctl('add-flow', 'idle_timeout=360,hard_timeout=1200,priority=10,'
                             'dl_vlan=324,actions=output:1')
        if restart_kytos:
            # restart controller keeping configuration
            self.net.start_controller()

        time.sleep(10)

        s1 = self.net.net.get('s1')
        flows_s1 = s1.dpctl('dump-flows')
        assert len(flows_s1.split('\r\n ')) == 2
>       assert 'in_port="s1-eth1' in flows_s1
E       assert 'in_port="s1-eth1' in ' cookie=0x0, duration=37.681s, table=0, n_packets=14, n_bytes=588, priority=1000,dl_vlan=3799,dl_type=0x88cc actions=...e=0, n_packets=0, n_bytes=0, idle_timeout=360, hard_timeout=1200, priority=10,dl_vlan=324 actions=output:"s1-eth1"\r\n'

tests/test_e2e_20_flow_manager.py:278: AssertionError
_________________________________________ TestE2EFlowManager.test_045_replace_action_flow_restarting _________________________________________

self = <tests.test_e2e_20_flow_manager.TestE2EFlowManager instance at 0x7f5bff7fb638>

    def test_045_replace_action_flow_restarting(self):
>       self.replace_action_flow(restart_kytos=True)

tests/test_e2e_20_flow_manager.py:346:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <tests.test_e2e_20_flow_manager.TestE2EFlowManager instance at 0x7f5bff7fb638>, restart_kytos = True

    def replace_action_flow(self, restart_kytos=False):

        payload = {
            "flows": [
                {
                    "priority": 10,
                    "idle_timeout": 360,
                    "hard_timeout": 1200,
                    "match": {
                        "in_port": 1
                    },
                    "actions": [
                        {
                            "action_type": "output",
                            "port": 2
                        }
                    ]
                }
            ]
        }

        api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
        response = requests.post(api_url, data=json.dumps(payload),
                                 headers={'Content-type': 'application/json'})
        assert response.status_code == 200
        data = response.json()
        assert 'FlowMod Messages Sent' in data['response']

        # wait for the flow to be installed
        time.sleep(10)

        # Verify the flow
        s1 = self.net.net.get('s1')
        flows_s1 = s1.dpctl('dump-flows')
        assert len(flows_s1.split('\r\n ')) == 2
        assert 'in_port="s1-eth1' in flows_s1

        # Modify the actions and verify its modification
        s1.dpctl('mod-flows', 'actions=output:3')
        flows_s1 = s1.dpctl('dump-flows')
        assert 'actions=output:"s1-eth2"' not in flows_s1
        assert 'actions=output:"s1-eth3"' in flows_s1

        if restart_kytos:
            # restart controller keeping configuration
            self.net.start_controller()

        time.sleep(10)

        # Check that the flow keeps the original setting
        s1 = self.net.net.get('s1')
        flows_s1 = s1.dpctl('dump-flows')
        assert len(flows_s1.split('\r\n ')) == 2
>       assert 'actions=output:"s1-eth3"' not in flows_s1
E       assert 'actions=output:"s1-eth3"' not in ' cookie=0x0, ..."s1-eth3"\r\n'
E         'actions=output:"s1-eth3"' is contained here:
E           pe=0x88cc actions=output:"s1-eth3"
E            cookie=0x0, duration=26.495s, table=0, n_packets=0, n_bytes=0, idle_timeout=360, hard_timeout=1200, priority=10,in_port="s1-eth1" actions=output:"s1-eth3"

tests/test_e2e_20_flow_manager.py:339: AssertionError
___________________________________________ TestE2EFlowManager.test_055_add_action_flow_restarting ___________________________________________

self = <tests.test_e2e_20_flow_manager.TestE2EFlowManager instance at 0x7f5bff7e44d0>

    def test_055_add_action_flow_restarting(self):
>       self.add_action_flow(restart_kytos=True)

tests/test_e2e_20_flow_manager.py:399:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <tests.test_e2e_20_flow_manager.TestE2EFlowManager instance at 0x7f5bff7e44d0>, restart_kytos = True

    def add_action_flow(self, restart_kytos=False):

        payload = {
            "flows": [
                {
                    "priority": 10,
                    "idle_timeout": 360,
                    "hard_timeout": 1200,
                    "match": {
                        "in_port": 1
                    },
                    "actions": [
                        {"action_type": "output", "port": 2}
                    ]
                }
            ]
        }

        api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
        response = requests.post(api_url, data=json.dumps(payload),
                                 headers={'Content-type': 'application/json'})
        assert response.status_code == 200
        data = response.json()
        assert 'FlowMod Messages Sent' in data['response']

        # wait for the flow to be installed
        time.sleep(10)

        # Verify the flow
        s1 = self.net.net.get('s1')
        flows_s1 = s1.dpctl('dump-flows')
        assert len(flows_s1.split('\r\n ')) == 2
        assert 'in_port="s1-eth1' in flows_s1

        s1.dpctl('add-flow', 'in_port=1,idle_timeout=360,hard_timeout=1200,priority=10,actions=strip_vlan,output:2')

        if restart_kytos:
            # restart controller keeping configuration
            self.net.start_controller()

        time.sleep(10)

        flows_s1 = s1.dpctl('dump-flows')
        assert len(flows_s1.split('\r\n ')) == 2
>       assert 'actions=strip_vlan,' not in flows_s1
E       assert 'actions=strip_vlan,' not in ' cookie=0x0, du...ut:"s1-eth2"\r\n'
E         'actions=strip_vlan,' is contained here:
E           "s1-eth1" actions=strip_vlan,output:"s1-eth2"

tests/test_e2e_20_flow_manager.py:392: AssertionError
_________________________________________ TestE2EFlowManager.test_065_flow_another_table_restarting __________________________________________

self = <tests.test_e2e_20_flow_manager.TestE2EFlowManager instance at 0x7f5bff7fba28>

    def test_065_flow_another_table_restarting(self):
>       self.flow_another_table(restart_kytos=True)

tests/test_e2e_20_flow_manager.py:421:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <tests.test_e2e_20_flow_manager.TestE2EFlowManager instance at 0x7f5bff7fba28>, restart_kytos = True

    def flow_another_table(self, restart_kytos=False):
        """Test if, after adding a flow in another table outside kytos, the
            flow is removed."""

        s1 = self.net.net.get('s1')
        s1.dpctl('add-flow', 'table=2,in_port=1,actions=output:2')
        if restart_kytos:
            # restart controller keeping configuration
            self.net.start_controller()

        time.sleep(10)

        s1 = self.net.net.get('s1')
        flows_s1 = s1.dpctl('dump-flows')
>       assert len(flows_s1.split('\r\n ')) == 1
E       assert 2 == 1
E        +  where 2 = len([' cookie=0x0, duration=27.056s, table=0, n_packets=8, n_bytes=336, priority=1000,dl_vlan=3799,dl_type=0x88cc actions=...5535', 'cookie=0x0, duration=16.157s, table=2, n_packets=0, n_bytes=0, in_port="s1-eth1" actions=output:"s1-eth2"\r\n'])
E        +    where [' cookie=0x0, duration=27.056s, table=0, n_packets=8, n_bytes=336, priority=1000,dl_vlan=3799,dl_type=0x88cc actions=...5535', 'cookie=0x0, duration=16.157s, table=2, n_packets=0, n_bytes=0, in_port="s1-eth1" actions=output:"s1-eth2"\r\n'] = <built-in method split of str object at 0x55a19d024440>('\r\n ')
E        +      where <built-in method split of str object at 0x55a19d024440> = ' cookie=0x0, duration=27.056s, table=0, n_packets=8, n_bytes=336, priority=1000,dl_vlan=3799,dl_type=0x88cc actions=C...5535\r\n cookie=0x0, duration=16.157s, table=2, n_packets=0, n_bytes=0, in_port="s1-eth1" actions=output:"s1-eth2"\r\n'.split

tests/test_e2e_20_flow_manager.py:415: AssertionError
____________________________________________ TestE2EFlowManager.test_075_flow_table_0_restarting _____________________________________________

self = <tests.test_e2e_20_flow_manager.TestE2EFlowManager instance at 0x7f5bff92dc68>

    def test_075_flow_table_0_restarting(self):
>       self.flow_table_0(restart_kytos=True)

tests/test_e2e_20_flow_manager.py:444:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <tests.test_e2e_20_flow_manager.TestE2EFlowManager instance at 0x7f5bff92dc68>, restart_kytos = True

    def flow_table_0(self, restart_kytos=False):
        """Test if, after adding a flow in another table outside kytos, the
            flow is removed."""

        s1 = self.net.net.get('s1')
        s1.dpctl('add-flow', 'table=0,in_port=1,actions=output:2')

        if restart_kytos:
            # restart controller keeping configuration
            self.net.start_controller()

        time.sleep(10)

        s1 = self.net.net.get('s1')
        flows_s1 = s1.dpctl('dump-flows')
>       assert len(flows_s1.split('\r\n ')) == 1
E       assert 2 == 1
E        +  where 2 = len([' cookie=0x0, duration=15.858s, table=0, n_packets=0, n_bytes=0, in_port="s1-eth1" actions=output:"s1-eth2"', 'cookie...on=26.629s, table=0, n_packets=8, n_bytes=336, priority=1000,dl_vlan=3799,dl_type=0x88cc actions=CONTROLLER:65535\r\n'])
E        +    where [' cookie=0x0, duration=15.858s, table=0, n_packets=0, n_bytes=0, in_port="s1-eth1" actions=output:"s1-eth2"', 'cookie...on=26.629s, table=0, n_packets=8, n_bytes=336, priority=1000,dl_vlan=3799,dl_type=0x88cc actions=CONTROLLER:65535\r\n'] = <built-in method split of str object at 0x55a19b2ea5c0>('\r\n ')
E        +      where <built-in method split of str object at 0x55a19b2ea5c0> = ' cookie=0x0, duration=15.858s, table=0, n_packets=0, n_bytes=0, in_port="s1-eth1" actions=output:"s1-eth2"\r\n cookie...ion=26.629s, table=0, n_packets=8, n_bytes=336, priority=1000,dl_vlan=3799,dl_type=0x88cc actions=CONTROLLER:65535\r\n'.split

tests/test_e2e_20_flow_manager.py:438: AssertionError
_______________________________________________ TestE2EOfLLDP.test_030_change_polling_interval _______________________________________________

self = <tests.test_e2e_30_of_lldp.TestE2EOfLLDP instance at 0x7f5bff764440>

    def test_030_change_polling_interval(self):
        """ Test if changing the polling interval works works properly. """
        self.net.restart_kytos_clean()

        api_url = KYTOS_API + '/of_lldp/v1/polling_time'
        response = requests.get(api_url)
        assert response.status_code == 200
        data = response.json()
        assert "polling_time" in data
        assert data["polling_time"] == 3

        h11 = self.net.net.get('h11')
        rx_stats_h11 = self.get_iface_stats_rx_pkt(h11)
        lldp_wait = 31
        time.sleep(lldp_wait)
        rx_stats_h11_2 = self.get_iface_stats_rx_pkt(h11)

        # the delta pps should be around 10, because the interface is every 3s
        delta_pps = rx_stats_h11_2 - rx_stats_h11

        api_url = KYTOS_API + '/of_lldp/v1/polling_time'
        response = requests.post(api_url, json={"polling_time": 1})
        assert response.status_code == 200

        response = requests.get(api_url)
        data = response.json()
        assert data["polling_time"] == 1

        rx_stats_h11 = self.get_iface_stats_rx_pkt(h11)
        time.sleep(lldp_wait)
        rx_stats_h11_2 = self.get_iface_stats_rx_pkt(h11)

        delta_pps_2 = rx_stats_h11_2 - rx_stats_h11

        # the delta pps now should be around 30, because the interval is every 1s
>       assert delta_pps_2 > delta_pps + 15
E       assert 26 > (11 + 15)

tests/test_e2e_30_of_lldp.py:205: AssertionError
=================================================== 9 failed, 52 passed in 2915.35 seconds ===================================================
```

This PR fixes both situations