### PR TITLE
New tests over the Flow manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .cache/
 __pycache__
 *.pyc
+venv/

--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -430,7 +430,7 @@ class TestE2EFlowManager:
 
     def test_021_delete_flow_on_non_existent_switch_should_fail(self):
         """Test if the flow deletion process specifying an invalid
-        path behaves as expected (404 Error)."""
+        switch behaves as expected (404 Error)."""
 
         payload = {
             "flows": [

--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -126,7 +126,7 @@ class TestE2EFlowManager:
         assert data[switch_id]["flows"][1]["idle_timeout"] == payload["flows"][0]["idle_timeout"]
         assert data[switch_id]["flows"][1]["hard_timeout"] == payload["flows"][0]["hard_timeout"]
 
-    def test_012_install_flow_on_non_existent_path_should_fail(self):
+    def test_012_install_flow_on_non_existent_switch_should_fail(self):
         """Test if the flow installation process on an
         unknown path behaves as expected (404 Error)."""
 

--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -1,4 +1,5 @@
 import json
+import pytest
 import requests
 from tests.helpers import NetworkTest
 import time
@@ -75,6 +76,179 @@ class TestE2EFlowManager:
         assert len(flows_s1.split('\r\n ')) == 2
         assert 'actions=output:"s1-eth2"' in flows_s1
 
+    def test_011_install_flow_and_retrieve_it_back(self):
+        """Test the flow status through the
+        API's call after its installation."""
+
+        switch_id = '00:00:00:00:00:00:00:01'
+
+        payload = {
+            "flows": [
+                {
+                    "priority": 10,
+                    "idle_timeout": 360,
+                    "hard_timeout": 1200,
+                    "match": {
+                        "in_port": 1
+                    },
+                    "actions": [
+                        {
+                            "action_type": "output",
+                            "port": 2
+                        }
+                    ]
+                }
+            ]
+        }
+
+        # It installs the flow
+        api_url = KYTOS_API + '/flow_manager/v2/flows/' + switch_id
+        requests.post(api_url, data=json.dumps(payload),
+                                 headers={'Content-type': 'application/json'})
+
+        # wait for the flow to be installed
+        time.sleep(10)
+
+        # restart controller keeping configuration
+        self.net.start_controller(enable_all=True, del_flows=True)
+        self.net.wait_switches_connect()
+
+        time.sleep(10)
+
+        response = requests.get(api_url, data=json.dumps(payload),
+                                 headers={'Content-type': 'application/json'})
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data[switch_id]["flows"]) == 2
+        assert data[switch_id]["flows"][1]["actions"] == payload["flows"][0]["actions"]
+        assert data[switch_id]["flows"][1]["match"] == payload["flows"][0]["match"]
+        assert data[switch_id]["flows"][1]["priority"] == payload["flows"][0]["priority"]
+        assert data[switch_id]["flows"][1]["idle_timeout"] == payload["flows"][0]["idle_timeout"]
+        assert data[switch_id]["flows"][1]["hard_timeout"] == payload["flows"][0]["hard_timeout"]
+
+    def test_012_install_flow_on_non_existent_path_should_fail(self):
+        """Test if the flow installation process on an
+        unknown path behaves as expected (404 Error)."""
+
+        payload = {
+            "flows": [
+                {
+                    "priority": 10,
+                    "idle_timeout": 360,
+                    "hard_timeout": 1200,
+                    "match": {
+                        "in_port": 1
+                    },
+                    "actions": [
+                        {
+                            "action_type": "output",
+                            "port": 2
+                        }
+                    ]
+                }
+            ]
+        }
+
+        api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:05'
+        response = requests.post(api_url, data=json.dumps(payload),
+                                 headers={'Content-type': 'application/json'})
+        assert response.status_code == 404
+
+    """
+    The Api call is returning 200 when should be 400
+    Issue https://github.com/kytos/flow_manager/issues/134
+    """
+    @pytest.mark.xfail
+    def test_0131_install_flow_should_fail(self):
+        """Test if the flow installation process specifying an empty
+        payload behaves as expected (400 Error)."""
+
+        payload = {}
+
+        api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
+        response = requests.post(api_url, data=json.dumps(payload),
+                                 headers={'Content-type': 'application/json'})
+        assert response.status_code == 400
+
+    """
+    The Api call is returning 200 when should be 400
+    Issue https://github.com/kytos/flow_manager/issues/134
+    """
+    @pytest.mark.xfail
+    def test_0132_install_flow_should_fail(self):
+        """Test if the flow installation process specifying an empty
+        flow data on the payload behaves as expected (400 Error)."""
+
+        payload = {
+            "flows": [
+            ]
+        }
+
+        api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
+        response = requests.post(api_url, data=json.dumps(payload),
+                                 headers={'Content-type': 'application/json'})
+        assert response.status_code == 400
+
+    """
+    The Api call is returning 200 when should be 400
+    Issue https://github.com/kytos/flow_manager/issues/134
+    """
+    @pytest.mark.xfail
+    def test_0133_install_flow_should_fail(self):
+        """Test if the flow installation process specifying an empty
+        flow data on the payload behaves as expected (400 Error)."""
+
+        payload = {
+            "flows": [
+                {
+
+                }
+            ]
+        }
+
+        api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
+        response = requests.post(api_url, data=json.dumps(payload),
+                                 headers={'Content-type': 'application/json'})
+        assert response.status_code == 400
+
+    """
+    The execution breaks when should be returning a 400
+    Issue https://github.com/kytos/flow_manager/issues/134
+    """
+    @pytest.mark.xfail
+    def test_0134_install_flow_should_fail(self):
+        """Test if the flow installation process specifying a
+        wrong datatype payload behaves as expected (400 Error)."""
+
+        payload = {
+            "flows": [
+                {
+                    "priority"
+                }
+            ]
+        }
+
+        api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
+        response = requests.post(api_url, data=json.dumps(payload),
+                                 headers={'Content-type': 'application/json'})
+        assert response.status_code == 400
+
+    """
+    The Api call is returning 500 when should be 404
+    Issue https://github.com/kytos/flow_manager/issues/131
+    """
+    @pytest.mark.xfail
+    def test_014_retrieve_flow_from_non_existent_path_should_fail(self):
+        """Test if the flow retrieving process of an unknown
+        path behaves as expected (404 Error)."""
+
+        switch_id = '00:00:00:00:00:00:00:05'
+
+        # It tries to get a flow that does not exist
+        api_url = KYTOS_API + '/flow_manager/v2/flows/' + switch_id
+        response = requests.get(api_url)
+        assert response.status_code == 404
+
     def test_015_install_flows(self):
         """Test if, after kytos restart, a flow installed to all switches will
            still be installed."""
@@ -119,6 +293,85 @@ class TestE2EFlowManager:
             flows_sw = sw.dpctl('dump-flows')
             assert len(flows_sw.split('\r\n ')) == 2
             assert 'actions=output:"%s-eth2"' % sw_name in flows_sw
+
+    """
+    The Api call is returning 200 when should be 400
+    Issue https://github.com/kytos/flow_manager/issues/132
+    """
+    @pytest.mark.xfail
+    def test_016_install_flows_should_fail(self):
+        """Test if the flow installation process specifying an empty
+        payload behaves as expected (400 Error)."""
+
+        payload = {}
+
+        api_url = KYTOS_API + '/flow_manager/v2/flows'
+        response = requests.post(api_url, data=json.dumps(payload),
+                                 headers={'Content-type': 'application/json'})
+        assert response.status_code == 400
+
+    """
+    The Api call is returning 200 when should be 400
+    Issue https://github.com/kytos/flow_manager/issues/132
+    """
+    @pytest.mark.xfail
+    def test_017_install_flows_should_fail(self):
+        """Test if the flow installation process specifying an empty
+        flow data on the payload behaves as expected (400 Error)."""
+
+        payload = {
+            "flows": [
+            ]
+        }
+
+        api_url = KYTOS_API + '/flow_manager/v2/flows'
+        response = requests.post(api_url, data=json.dumps(payload),
+                                 headers={'Content-type': 'application/json'})
+        assert response.status_code == 400
+
+    """
+    The Api call is returning 200 when should be 400
+    Issue https://github.com/kytos/flow_manager/issues/132
+    """
+    @pytest.mark.xfail
+    def test_018_install_flows_should_fail(self):
+        """Test if the flow installation process specifying an empty
+        flow data on the payload behaves as expected (400 Error)."""
+
+        payload = {
+            "flows": [
+                {
+
+                }
+            ]
+        }
+
+        api_url = KYTOS_API + '/flow_manager/v2/flows'
+        response = requests.post(api_url, data=json.dumps(payload),
+                                 headers={'Content-type': 'application/json'})
+        assert response.status_code == 400
+
+    """
+    The Api call fails on runtime when should return a 400
+    Issue https://github.com/kytos/flow_manager/issues/132
+    """
+    @pytest.mark.xfail
+    def test_019_install_flows_should_fail(self):
+        """Test if the flow installation process specifying a
+        wrong datatype payload behaves as expected (400 Error)."""
+
+        payload = {
+            "flows": [
+                {
+                    "priority"
+                }
+            ]
+        }
+
+        api_url = KYTOS_API + '/flow_manager/v2/flows'
+        response = requests.post(api_url, data=json.dumps(payload),
+                                 headers={'Content-type': 'application/json'})
+        assert response.status_code == 400
 
     def test_020_delete_flow(self):
         """Test if, after kytos restart, a flow deleted from a switch will
@@ -175,6 +428,118 @@ class TestE2EFlowManager:
         assert len(flows_s1.split('\r\n ')) == 1
         assert 'actions=output:"s1-eth2"' not in flows_s1
 
+    def test_021_delete_flow_on_non_existent_path_should_fail(self):
+        """Test if the flow deletion process specifying an unknown
+        path behaves as expected (404 Error)."""
+
+        payload = {
+            "flows": [
+                {
+                    "priority": 10,
+                    "idle_timeout": 360,
+                    "hard_timeout": 1200,
+                    "match": {
+                        "in_port": 1
+                    },
+                    "actions": [
+                        {
+                            "action_type": "output",
+                            "port": 2
+                        }
+                    ]
+                }
+            ]
+        }
+
+        # delete the flow
+        api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:05'
+        response = requests.delete(api_url, data=json.dumps(payload),
+                                   headers={'Content-type': 'application/json'})
+        assert response.status_code == 404
+
+    """
+    The Api call is returning 200 when should be 400
+    Issue https://github.com/kytos/flow_manager/issues/136
+    """
+    @pytest.mark.xfail
+    def test_022_delete_flow_should_fail(self):
+        """Test if the flow deletion process specifying an empty
+        payload behaves as expected (400 Error)."""
+
+        payload = {}
+
+        # delete the flow
+        api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
+        response = requests.delete(api_url, data=json.dumps(payload),
+                                   headers={'Content-type': 'application/json'})
+        assert response.status_code == 400
+
+    """
+    The Api call is returning 200 when should be 400
+    Issue https://github.com/kytos/flow_manager/issues/136
+    """
+    @pytest.mark.xfail
+    def test_023_delete_flow_should_fail(self):
+        """Test if the flow deletion process specifying an empty
+        flow data on the payload behaves as expected (400 Error)."""
+
+        payload = {
+            "flows": [
+            ]
+        }
+
+        # delete the flow
+        api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
+        response = requests.delete(api_url, data=json.dumps(payload),
+                                   headers={'Content-type': 'application/json'})
+        assert response.status_code == 400
+
+    """
+    The Api call is returning 200 when should be 400
+    Issue https://github.com/kytos/flow_manager/issues/136
+    """
+    @pytest.mark.xfail
+    def test_024_delete_flow_should_fail(self):
+        """Test if the flow deletion process specifying an an empty
+        flow data on the payload behaves as expected (400 Error)."""
+
+        payload = {
+            "flows": [
+                {
+
+                }
+            ]
+        }
+
+        # delete the flow
+        api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
+        response = requests.delete(api_url, data=json.dumps(payload),
+                                   headers={'Content-type': 'application/json'})
+        assert response.status_code == 400
+
+    """
+    The Api call fails on runtime when should return a 400
+    Issue https://github.com/kytos/flow_manager/issues/136
+    """
+    @pytest.mark.xfail
+    def test_0241_delete_flow_should_fail(self):
+        """Test if the flow deletion process specifying a
+        wrong datatype payload behaves as expected (400 Error)."""
+
+        payload = {
+            "flows": [
+                {
+                    "priority"
+                }
+            ]
+        }
+
+        # delete the flow
+        api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
+        response = requests.delete(api_url, data=json.dumps(payload),
+                                   headers={'Content-type': 'application/json'})
+        assert response.status_code == 400
+
     def test_025_delete_flows(self):
         """Test if, after kytos restart, a flow deleted from all switches will
            still be deleted."""
@@ -230,6 +595,89 @@ class TestE2EFlowManager:
             flows_sw = sw.dpctl('dump-flows')
             assert len(flows_sw.split('\r\n ')) == 1
             assert 'actions=output:"%s-eth2"' % sw_name not in flows_sw
+
+    """
+    The Api call is returning 200 when should be 400
+    Issue https://github.com/kytos/flow_manager/issues/135
+    """
+    @pytest.mark.xfail
+    def test_026_delete_flows_should_fail(self):
+        """Test if the flow deletion process specifying an empty
+        payload behaves as expected (400 Error)."""
+
+        payload = {}
+
+        # delete the flow
+        api_url = KYTOS_API + '/flow_manager/v2/flows'
+        response = requests.delete(api_url, data=json.dumps(payload),
+                                   headers={'Content-type': 'application/json'})
+        assert response.status_code == 400
+
+    """
+    The Api call is returning 200 when should be 400
+    Issue https://github.com/kytos/flow_manager/issues/135
+    """
+    @pytest.mark.xfail
+    def test_027_delete_flows_should_fail(self):
+        """Test if the flow deletion process specifying an empty
+        flow data on the payload behaves as expected (400 Error)."""
+
+        payload = {
+            "flows": [
+            ]
+        }
+
+        # delete the flow
+        api_url = KYTOS_API + '/flow_manager/v2/flows'
+        response = requests.delete(api_url, data=json.dumps(payload),
+                                   headers={'Content-type': 'application/json'})
+        assert response.status_code == 400
+
+    """
+    The Api call is returning 200 when should be 400
+    Issue https://github.com/kytos/flow_manager/issues/135
+    """
+    @pytest.mark.xfail
+    def test_028_delete_flows_should_fail(self):
+        """Test if the flow deletion process specifying an empty
+        flow data on the payload behaves as expected (400 Error)."""
+
+        payload = {
+            "flows": [
+                {
+
+                }
+            ]
+        }
+
+        # delete the flow
+        api_url = KYTOS_API + '/flow_manager/v2/flows'
+        response = requests.delete(api_url, data=json.dumps(payload),
+                                   headers={'Content-type': 'application/json'})
+        assert response.status_code == 400
+
+    """
+    The Api call fails on runtime when should return a 400
+    Issue https://github.com/kytos/flow_manager/issues/135
+    """
+    @pytest.mark.xfail
+    def test_029_delete_flows_should_fail(self):
+        """Test if the flow deletion process specifying a
+        wrong datatype payload behaves as expected (400 Error)."""
+
+        payload = {
+            "flows": [
+                {
+                    "priority"
+                }
+            ]
+        }
+
+        # delete the flow
+        api_url = KYTOS_API + '/flow_manager/v2/flows'
+        response = requests.delete(api_url, data=json.dumps(payload),
+                                   headers={'Content-type': 'application/json'})
+        assert response.status_code == 400
 
     def modify_match(self, restart_kytos=False):
         """Test if after a match is modified outside kytos, the original
@@ -404,7 +852,7 @@ class TestE2EFlowManager:
         self.add_action_flow(restart_kytos=True)
 
     def flow_another_table(self, restart_kytos=False):
-        """Test if, after adding a flow in another table outside kytos, the 
+        """Test if, after adding a flow in another table outside kytos, the
             flow is removed."""
 
         s1 = self.net.net.get('s1')

--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -240,7 +240,7 @@ class TestE2EFlowManager:
     @pytest.mark.xfail
     def test_014_retrieve_flow_from_non_existent_switch_should_fail(self):
         """Test if the flow retrieving process of an unknown
-        path behaves as expected (404 Error)."""
+        switch behaves as expected (404 Error)."""
 
         switch_id = '00:00:00:00:00:00:00:05'
 

--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -428,7 +428,7 @@ class TestE2EFlowManager:
         assert len(flows_s1.split('\r\n ')) == 1
         assert 'actions=output:"s1-eth2"' not in flows_s1
 
-    def test_021_delete_flow_on_non_existent_path_should_fail(self):
+    def test_021_delete_flow_on_non_existent_switch_should_fail(self):
         """Test if the flow deletion process specifying an unknown
         path behaves as expected (404 Error)."""
 

--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -239,7 +239,7 @@ class TestE2EFlowManager:
     """
     @pytest.mark.xfail
     def test_014_retrieve_flow_from_non_existent_switch_should_fail(self):
-        """Test if the flow retrieving process of an unknown
+        """Test if the flow retrieving process of an invalid
         switch behaves as expected (404 Error)."""
 
         switch_id = '00:00:00:00:00:00:00:05'

--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -238,7 +238,7 @@ class TestE2EFlowManager:
     Issue https://github.com/kytos/flow_manager/issues/131
     """
     @pytest.mark.xfail
-    def test_014_retrieve_flow_from_non_existent_path_should_fail(self):
+    def test_014_retrieve_flow_from_non_existent_switch_should_fail(self):
         """Test if the flow retrieving process of an unknown
         path behaves as expected (404 Error)."""
 

--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -128,7 +128,7 @@ class TestE2EFlowManager:
 
     def test_012_install_flow_on_non_existent_switch_should_fail(self):
         """Test if the flow installation process on an
-        unknown path behaves as expected (404 Error)."""
+        invalid switch behaves as expected (404 Error)."""
 
         payload = {
             "flows": [

--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -429,7 +429,7 @@ class TestE2EFlowManager:
         assert 'actions=output:"s1-eth2"' not in flows_s1
 
     def test_021_delete_flow_on_non_existent_switch_should_fail(self):
-        """Test if the flow deletion process specifying an unknown
+        """Test if the flow deletion process specifying an invalid
         path behaves as expected (404 Error)."""
 
         payload = {

--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -32,8 +32,8 @@ class TestE2EFlowManager:
         cls.net.stop()
 
     def test_010_install_flow(self):
-        """Test if, after kytos restart, a flow installed to a switch will
-           still be installed."""
+        """Test if, after kytos restart, a flow installed
+        to a switch will still be installed."""
 
         payload = {
             "flows": [
@@ -234,8 +234,6 @@ class TestE2EFlowManager:
     def modify_match(self, restart_kytos=False):
         """Test if after a match is modified outside kytos, the original
            flow is restored."""
-        # self.net.restart_kytos_clean()
-        # time.sleep(10)
 
         payload = {
             "flows": [
@@ -451,4 +449,3 @@ class TestE2EFlowManager:
 
     def test_075_flow_table_0_restarting(self):
         self.flow_table_0(restart_kytos=True)
-

--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -451,3 +451,4 @@ class TestE2EFlowManager:
 
     def test_075_flow_table_0_restarting(self):
         self.flow_table_0(restart_kytos=True)
+


### PR DESCRIPTION
New tests to verify the NApp behavior against certain failures.

The commits include:

- Inclusion of pytest module to support the xfail actions
- New test to evaluate the flow status through the API's call after its installation
- New test to evaluate the behavior of the flow installation process on an unknown path
- New test to evaluate the behavior of the flow installation process specifying an empty payload (over different scenarios)
- New test to evaluate the behavior of the flow installation process specifying a wrong datatype payload
- New test to evaluate the behavior of the flow retrieving process of an unknown path
- New test to evaluate the behavior of the flow installation process specifying an empty payload (over different scenarios)
- New test to evaluate the behavior of the flow installation process specifying a wrong datatype payload
- New test to evaluate the behavior of the flow deletion process over a switch specifying an unknown path
- New test to evaluate the behavior of the flow deletion process over a switch specifying an empty payload (over different scenarios)
- New test to evaluate the behavior of the flow deletion process over a switch specifying a wrong datatype payload
- New test to evaluate the behavior of all flows deletion process specifying an empty payload (over different scenarios)
- New test to evaluate the behavior of all flows deletion process over a switch specifying a wrong datatype payload
- Updates on the documentation