### PR TITLE
Fix sleeps which were possible source of problems

### DIFF
--- a/tests/test_e2e_15_maintenance.py
+++ b/tests/test_e2e_15_maintenance.py
@@ -102,7 +102,7 @@ class TestE2EMaintenance:
         assert 'mw_id' in data
 
         # Waits for the MW to start
-        time.sleep(mw_start_delay+5)
+        time.sleep(mw_start_delay+10)
 
         # Switch 1 and 3 should have 3 flows; Switch 2 should have only 1 flow.
         s1, s2, s3 = self.net.net.get('s1', 's2', 's3')

--- a/tests/test_e2e_30_of_lldp.py
+++ b/tests/test_e2e_30_of_lldp.py
@@ -131,7 +131,7 @@ class TestE2EOfLLDP:
         # restart kytos and check if lldp remains disabled
         self.net.start_controller(clean_config=False, enable_all=False)
         self.net.wait_switches_connect()
-        time.sleep(5)
+        time.sleep(10)
 
         api_url = KYTOS_API + '/of_lldp/v1/interfaces/'
         response = requests.get(api_url)
@@ -174,7 +174,7 @@ class TestE2EOfLLDP:
         # restart kytos and check if lldp remains disabled
         self.net.start_controller(clean_config=False, enable_all=False)
         self.net.wait_switches_connect()
-        time.sleep(5)
+        time.sleep(10)
 
         api_url = KYTOS_API + '/of_lldp/v1/interfaces/'
         response = requests.get(api_url)


### PR DESCRIPTION
The tests for of_lldp and maintenance sometimes fail and that could be due to the time.sleep(5) in the test. Since we are going to a standard of 10s after restarting the controller, I changed some tests to reflect that.