### PR TITLE
Fix test to verify preservation of flows during startup

### DIFF
--- a/tests/test_e2e_21_flow_manager.py
+++ b/tests/test_e2e_21_flow_manager.py
@@ -79,6 +79,8 @@ class TestE2EFlowManager:
         flows_s1 = s1.dpctl('dump-flows')
         assert len(flows_s1.split('\r\n ')) == 2
         for flow in flows_s1.split('\r\n '):
+            # Check all flows but the of_lldp, which is reinstalled
+            if 'dl_vlan=3799,dl_type=0x88cc' in flow: continue
             match = re.search("duration=([0-9.]+)", flow)
             duration = float(match.group(1))
             assert duration >= wait_time + delta


### PR DESCRIPTION
Currently, there is a test in flow_manage (`tests/test_e2e_21_flow_manager.py::TestE2EFlowManager::test_030_restart_kytos_should_preserve_flows`) which verifies if during kytos restart the flows are preserved. All the flows created by the user should be preserved, thus avoiding traffic disruption.

A especial case is the flows created by other kytos napps, such as of_lldp: since the flows are resubmitted every time the of_lldp napp is loaded, the flow_manage will send a FlowMod and the flow will be recreated. Since this especial case does not affect the user traffic, there is no risk in ignoring this behavior. The test was working before because when we restart kytos (tests/test_e2e_21_flow_manager.py L70) we leave all the switches disable (enable_all=False), then flow_manager will not send FlowMod for disabled switches.

This patch fix the above behavior.