### PR TITLE
Add new test to mef_eline delete when no switches are connected

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -96,7 +96,7 @@ class NetworkTest:
         self.net.start()
         self.start_controller(clean_config=True)
 
-    def start_controller(self, clean_config=False, enable_all=False, del_flows=False):
+    def start_controller(self, clean_config=False, enable_all=False, del_flows=False, port=None):
         # Restart kytos and check if the napp is still disabled
         try:
             os.system('pkill kytosd')
@@ -118,6 +118,8 @@ class NetworkTest:
                 sw.dpctl('del-flows')
 
         daemon = 'kytosd'
+        if port:
+            daemon += ' --port %s' % port
         if enable_all:
             daemon += ' -E'
         os.system(daemon)

--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -32,6 +32,25 @@ class TestE2EMefEline:
     def teardown_class(cls):
         cls.net.stop()
 
+    def create_evc(self, vlan_id):
+        payload = {
+            "name": "Vlan_%s" % vlan_id,
+            "enabled": True,
+            "dynamic_backup_path": True,
+            "uni_a": {
+                "interface_id": "00:00:00:00:00:00:00:01:1",
+                "tag": {"tag_type": 1, "value": vlan_id}
+            },
+            "uni_z": {
+                "interface_id": "00:00:00:00:00:00:00:02:1",
+                "tag": {"tag_type": 1, "value": vlan_id}
+            }
+        }
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
+        data = response.json()
+        return  data['circuit_id']
+
     def test_010_list_evcs_should_be_empty(self):
         """Test if list circuits return 'no circuit stored.'."""
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
@@ -482,6 +501,30 @@ class TestE2EMefEline:
     def test_065_on_primary_path_fail_should_migrate_to_backup(self):
         # TODO
         assert True
+
+    def test_070_delete_evc_after_restart_kytos_and_no_switch_reconnected(self)
+        evc1 = self.create_evc(100)
+
+        # restart the controller and change the port on purpose to avoid switches to connect
+        self.net.start_controller(clean_config=False, enable_all=True, port=9999)
+        time.sleep(10)
+
+        # Delete the circuit
+        response = requests.delete(api_url + evc1)
+        assert response.status_code == 200
+        time.sleep(10)
+
+        response = requests.get(api_url)
+        assert response.status_code == 200
+        data = response.json()
+        assert evc1 not in data
+
+        response = requests.get(api_url, params={'archived': True})
+        assert response.status_code == 200
+        data = response.json()
+        assert evc1 in data
+        assert data[evc1]['archived'] is True
+        assert data[evc1]['active'] is False
 
     def patch_evc_by_changing_unis_from_interface_to_another(self):
         # TODO


### PR DESCRIPTION
This is related to the issue https://github.com/kytos-ng/topology/issues/11

When Kytos is restarted, the topology only loads the switches, interfaces and links from storehouse after all the switches reconnect. Thus, if you wanna delete an EVC on Kytos startup, you will have to wait until the switches to connect, then mef_eline is able to load the EVCs and only then you can finally delete the EVC.

This PR adds a new test to evaluate this behavior. Since there is a PR already opened and under review to fix this issue (the PR's patch was already applied on the Kytos amlight docker image), I didn't add the pytest xfail decorator.