### PR TITLE
Removing the xfailing routines in order to activate the latest tests

### DIFF
--- a/tests/test_e2e_15_maintenance.py
+++ b/tests/test_e2e_15_maintenance.py
@@ -2,7 +2,6 @@ import json
 import time
 from datetime import datetime, timedelta
 
-import pytest
 import requests
 
 from tests.helpers import NetworkTest
@@ -433,7 +432,6 @@ class TestE2EMaintenance:
         api_url = KYTOS_API + '/maintenance/' + mw_id
         requests.delete(api_url)
 
-    @pytest.mark.xfail
     def test_050_patch_mw_on_switch_should_fail_wrong_payload_items_empty(self):
         """
         400 response calling
@@ -872,7 +870,6 @@ class TestE2EMaintenance:
         api_url = KYTOS_API + '/maintenance/' + mw_id
         requests.delete(api_url)
 
-    @pytest.mark.xfail
     def test_095_extend_running_mw_on_switch(self):
 
         self.restart_and_create_circuit()
@@ -969,7 +966,6 @@ class TestE2EMaintenance:
         h11.cmd('ip link del vlan100')
         h3.cmd('ip link del vlan100')
 
-    @pytest.mark.xfail
     def test_100_extend_no_running_mw_on_switch_should_fail(self):
         self.restart_and_create_circuit()
 
@@ -1005,7 +1001,6 @@ class TestE2EMaintenance:
         response = requests.patch(api_url, data=json.dumps(payload2), headers={'Content-type': 'application/json'})
         assert response.status_code == 400
 
-    @pytest.mark.xfail
     def test_105_extend_unknown_mw_on_switch_should_fail(self):
         self.restart_and_create_circuit()
 
@@ -1019,7 +1014,6 @@ class TestE2EMaintenance:
         response = requests.patch(api_url, data=json.dumps(payload2), headers={'Content-type': 'application/json'})
         assert response.status_code == 404
 
-    @pytest.mark.xfail
     def test_110_extend_running_mw_on_switch_under_unknown_tag_should_fail(self):
         self.restart_and_create_circuit()
 
@@ -1058,7 +1052,6 @@ class TestE2EMaintenance:
         response = requests.patch(api_url, data=json.dumps(payload2), headers={'Content-type': 'application/json'})
         assert response.status_code == 400
 
-    @pytest.mark.xfail
     def test_115_extend_ended_mw_on_switch_should_fail(self):
         self.restart_and_create_circuit()
 


### PR DESCRIPTION
This PR removes all the xfailing routines activating all the maintenance tests and monitoring processes.