### PR TITLE
It fixes patching actions return codes.

### DIFF
--- a/tests/test_e2e_15_maintenance.py
+++ b/tests/test_e2e_15_maintenance.py
@@ -310,7 +310,7 @@ class TestE2EMaintenance:
         # Updates the maintenance window information
         mw_api_url = KYTOS_API + '/maintenance/' + mw_id
         request = requests.patch(mw_api_url, data=json.dumps(payload1), headers={'Content-type': 'application/json'})
-        assert request.status_code == 201
+        assert request.status_code == 200
 
         # Gets the maintenance window schema
         api_url = KYTOS_API + '/maintenance/' + mw_id
@@ -646,7 +646,7 @@ class TestE2EMaintenance:
         # Updates the maintenance window information
         mw_api_url = KYTOS_API + '/maintenance/' + mw_id
         request = requests.patch(mw_api_url, data=json.dumps(payload1), headers={'Content-type': 'application/json'})
-        assert request.status_code == 201
+        assert request.status_code == 200
 
         # Gets the maintenance window schema
         api_url = KYTOS_API + '/maintenance/' + mw_id
@@ -873,7 +873,7 @@ class TestE2EMaintenance:
         # Ends the maintenance window information
         api_url = KYTOS_API + '/maintenance/' + mw_id + '/end'
         end_response = requests.patch(api_url)
-        assert end_response.status_code == 201
+        assert end_response.status_code == 200
 
         # Waits to the time that the MW should be ended but instead will be running (extended)
         time.sleep(10)
@@ -1005,7 +1005,7 @@ class TestE2EMaintenance:
         # extend the maintenance window information
         api_url = KYTOS_API + '/maintenance/' + mw_id + '/extend'
         response = requests.patch(api_url, data=json.dumps(payload2), headers={'Content-type': 'application/json'})
-        assert response.status_code == 201
+        assert response.status_code == 200
 
         # Waits to the time that the MW should be ended but instead will be running (extended)
         time.sleep(mw_duration + 5)


### PR DESCRIPTION
## Description of the Change
The new contribution enforces a strict correlation between actions and their return codes for all the cases evaluated, such as:

- It is fixed the patching action on '/maintenance/{mw_id},' returning 200 in case of success.
- It is fixed the patching action on '/maintenance/{mw_id}/end,' returning 200 in case of success.
- It is fixed the patching action on '/maintenance/{mw_id}/extend,' returning 200 in case of success.

## Release Notes
N/A
