### PR TITLE
Fix order of links in backup_path for test mef_eline_11 / test_135_patch_backup_path

### DIFF
--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -1055,8 +1055,8 @@ class TestE2EMefEline:
 
         payload2 = {
             "backup_path": [
-                {"endpoint_a": {"id": "00:00:00:00:00:00:00:03:3"},
-                 "endpoint_b": {"id": "00:00:00:00:00:00:00:01:4"}}
+                {"endpoint_a": {"id": "00:00:00:00:00:00:00:01:4"},
+                 "endpoint_b": {"id": "00:00:00:00:00:00:00:03:3"}}
             ]
         }
 


### PR DESCRIPTION
This PR fixes a minor issue on the order which the backup path was specified in the payload. Since the kytos core mandates the order of the NNIs in a Link object, this PR fixes the payload to match the expected order.