### PR TITLE
Add helper to set all links up as part of setup_method and remove some xfail decorator

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -193,6 +193,14 @@ class NetworkTest:
         self.start_controller(clean_config=True, enable_all=True)
         self.wait_switches_connect()
 
+    def config_all_links_up(self):
+        for link in self.net.links:
+            self.net.configLinkStatus(
+                link.intf1.node.name,
+                link.intf2.node.name,
+                "up"
+            )
+
     def stop(self):
         self.net.stop()
         mininet.clean.cleanup()

--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -916,8 +916,6 @@ class TestE2EMefEline:
         assert 'priority=100' in flows_s1
         assert 'priority=100' in flows_s2
 
-    """It does not contain the queue information in the flow description"""
-    @pytest.mark.xfail
     def test_120_patch_queue_id(self):
 
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
@@ -1238,7 +1236,6 @@ class TestE2EMefEline:
         assert data['enabled'] is True
         assert data['current_path'] == []
 
-    @pytest.mark.xfail
     def test_155_removing_evc_metadata_persistent(self):
         """
         Test /api/kytos/mef_eline/v2/evc/{evc_id}/metadata/{key} on DELETE

--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -22,6 +22,9 @@ class TestE2EMefEline:
         """
         It is called at the beginning of every class method execution
         """
+        # Since some tests may set a link to down state, we should reset
+        # the link state to up (for all links)
+        self.net.config_all_links_up()
         # Start the controller setting an environment in
         # which all elements are disabled in a clean setting
         self.net.start_controller(clean_config=True, enable_all=True)

--- a/tests/test_e2e_11_mef_eline.py
+++ b/tests/test_e2e_11_mef_eline.py
@@ -76,7 +76,7 @@ class TestE2EMefEline:
 
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
 
         time.sleep(10)
 
@@ -140,7 +140,8 @@ class TestE2EMefEline:
         }
 
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
-        requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
+        r = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
+        assert r.status_code == 201, r.text
 
         time.sleep(10)
 
@@ -200,7 +201,8 @@ class TestE2EMefEline:
         }
 
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
-        requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
+        r = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
+        assert r.status_code == 201, r.text
 
         time.sleep(10)
 
@@ -251,7 +253,7 @@ class TestE2EMefEline:
 
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
 
         time.sleep(10)
 
@@ -281,8 +283,6 @@ class TestE2EMefEline:
         h1.cmd('ip link del vlan101')
         h2.cmd('ip link del vlan101')
 
-    """It is returning 201 but should be 400 due to the presence of an only read attribute on Post (active)"""
-    @pytest.mark.xfail
     def test_025_should_fail_due_to_invalid_attribute_on_payload(self):
         payload = {
             "name": "my evc1",

--- a/tests/test_e2e_11_mef_eline.py
+++ b/tests/test_e2e_11_mef_eline.py
@@ -17,6 +17,9 @@ class TestE2EMefEline:
         """
         It is called at the beginning of every class method execution
         """
+        # Since some tests may set a link to down state, we should reset
+        # the link state to up (for all links)
+        self.net.config_all_links_up()
         # Start the controller setting an environment in
         # which all elements are disabled in a clean setting
         self.net.restart_kytos_clean()

--- a/tests/test_e2e_13_mef_eline.py
+++ b/tests/test_e2e_13_mef_eline.py
@@ -21,6 +21,9 @@ class TestE2EMefEline:
         """
         It is called at the beginning of every class method execution
         """
+        # Since some tests may set a link to down state, we should reset
+        # the link state to up (for all links)
+        self.net.config_all_links_up()
         # Start the controller setting an environment in
         # which all elements are disabled in a clean setting
         self.net.start_controller(clean_config=True, enable_all=True)

--- a/tests/test_e2e_13_mef_eline.py
+++ b/tests/test_e2e_13_mef_eline.py
@@ -640,8 +640,6 @@ class TestE2EMefEline:
         assert paths == payload1["backup_path"]
         assert data['active'] is True
 
-    """It is returning Response [200], should be 400"""
-    @pytest.mark.xfail
     def test_125_patch_an_unrelated_backup_path(self):
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         payload1 = {
@@ -899,8 +897,6 @@ class TestE2EMefEline:
         assert paths == payload1["backup_links"]
         assert data['active'] is True
 
-    """It is returning Response 500, but it should return a failure code"""
-    @pytest.mark.xfail
     def test_150_patch_creation_time(self):
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
@@ -965,8 +961,6 @@ class TestE2EMefEline:
         data = response.json()
         assert data['request_time'] != start.strftime(TIME_FMT)
 
-    """It is returning Response 500, but it should return a failure code"""
-    @pytest.mark.xfail
     def test_165_patch_current_path(self):
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         payload1 = {
@@ -1103,8 +1097,6 @@ class TestE2EMefEline:
         response = requests.get(api_url + evc1 + "A")
         assert response.status_code == 404
 
-    """It is returning Response 500, should be 400"""
-    @pytest.mark.xfail
     def test_200_post_on_dynamic_backup_path_and_backup_path(self):
         payload = {
             "name": "my evc1",
@@ -1128,8 +1120,6 @@ class TestE2EMefEline:
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 400
 
-    """It is returning Response 201, should be 400"""
-    @pytest.mark.xfail
     def test_205_post_on_false_dynamic_backup_path_and_empty_primary_path(self):
         payload = {
             "name": "my evc1",
@@ -1150,8 +1140,6 @@ class TestE2EMefEline:
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 400
 
-    """It is returning Response 201, should be 400"""
-    @pytest.mark.xfail
     def test_210_post_on_false_dynamic_backup_path_and_none_primary_path(self):
         payload = {
             "name": "my evc1",
@@ -1171,8 +1159,6 @@ class TestE2EMefEline:
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 400
 
-    """It is returning Response 201, should be 400"""
-    @pytest.mark.xfail
     def test_215_post_on_none_dynamic_backup_path_and_empty_primary_path(self):
         payload = {
             "name": "my evc1",
@@ -1192,8 +1178,6 @@ class TestE2EMefEline:
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
         assert response.status_code == 400
 
-    """It is returning Response 201, should be 400"""
-    @pytest.mark.xfail
     def test_220_post_on_none_dynamic_backup_path_and_none_primary_path(self):
         payload = {
             "name": "my evc1",

--- a/tests/test_e2e_14_mef_eline.py
+++ b/tests/test_e2e_14_mef_eline.py
@@ -15,6 +15,9 @@ class TestE2EMefEline:
         """
         It is called at the beginning of every class method execution
         """
+        # Since some tests may set a link to down state, we should reset
+        # the link state to up (for all links)
+        self.net.config_all_links_up()
         # Start the controller setting an environment in
         # which all elements are disabled in a clean setting
         self.net.start_controller(clean_config=True, enable_all=True)


### PR DESCRIPTION
This PR adds a new helper function which sets all links up. This is useful for tests which disables interfaces or links in order to test how Kytos will react. Those tests, must guarantee that they will set the interfaces or links up again to reset the state for the next test. Thus, I've created a helper method `config_all_links_up ` which can be called from `setup_method()` to make sure all links/interfaces are UP. The mef_eline testing code was updated to include this helper call.

I've also took the opportunity to remove some xfail decorator from tests with solved issues.

Finally, I've added assertions on the response status_code for `tests/test_e2e_11_mef_eline.py` since their failure were during the creation phase.