### PR TITLE
Fix test for mef_eline by adding the proper wait time

### DIFF
--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -723,6 +723,9 @@ class TestE2EMefEline:
         for thread in threads:
             thread.join()
 
+        # give some time so Kytos can create the flows and everything
+        time.sleep(10)
+
         # make sure the evcs are active and the flows were created
         s1, s2 = self.net.net.get('s1', 's2')
         flows_s1 = s1.dpctl('dump-flows')


### PR DESCRIPTION
This PR adds a new sleep into `tests/test_e2e_10_mef_eline.py::TestE2EMefEline:: test_085_create_and_remove_ten_circuit_concurrently` to fix borderline cases where the flows were just submitted and Kytos didnt have enough time to create the actual flows.