### PR TITLE
Add extra assertions to help troubleshooting

### DIFF
--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -1273,6 +1273,7 @@ class TestE2EMefEline:
 
         # Make sure the metadata is still there
         response = requests.get(api_url)
+        assert response.status_code == 200, response.text
         data = response.json()
         assert data['metadata'] == payload
 
@@ -1282,6 +1283,7 @@ class TestE2EMefEline:
 
         # Make sure the metadata was deleted
         response = requests.get(api_url)
+        assert response.status_code == 200, response.text
         data = response.json()
         assert my_key not in data['metadata']
         assert len(data['metadata']) > 0
@@ -1290,6 +1292,7 @@ class TestE2EMefEline:
 
         # Make sure the metadata is still not there
         response = requests.get(api_url)
+        assert response.status_code == 200, response.text
         data = response.json()
         assert my_key not in data['metadata']
         assert len(data['metadata']) > 0


### PR DESCRIPTION
This PR just adds a few assertions on the return code of `/api/kytos/mef_eline/v2/evc/{evc_id}/metadata` API to help to troubleshoot in case of failure (such as what we are seeing in kytos-ng/mef_eline#130).