### PR TITLE
Add response.text to all assertions on request status code

### DIFF
--- a/tests/test_e2e_01_kytos_startup.py
+++ b/tests/test_e2e_01_kytos_startup.py
@@ -45,7 +45,7 @@ class TestE2EKytosServer:
         # Check server status if it is UP and running
         api_url = KYTOS_API+'/core/status/'
         response = requests.get(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         data = response.json()
         assert data['response'] == 'running'
@@ -63,7 +63,7 @@ class TestE2EKytosServer:
             ]
         api_url = KYTOS_API+'/core/napps_enabled/'
         response = requests.get(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         data = response.json()
         assert set([tuple(lst) for lst in data['napps']]) == set(expected_napps)
@@ -71,11 +71,11 @@ class TestE2EKytosServer:
         # Check disable a napp
         api_url = KYTOS_API+'/core/napps/kytos/mef_eline/disable'
         response = requests.get(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         api_url = KYTOS_API+'/core/napps_enabled/'
         response = requests.get(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         data = response.json()
         assert set([tuple(lst) for lst in data['napps']]) == set(expected_napps) - set([("kytos", "mef_eline")])
@@ -86,7 +86,7 @@ class TestE2EKytosServer:
 
         api_url = KYTOS_API+'/core/napps_enabled/'
         response = requests.get(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         data = response.json()
         assert set([tuple(lst) for lst in data['napps']]) == set(expected_napps) - set([("kytos", "mef_eline")])
@@ -94,11 +94,11 @@ class TestE2EKytosServer:
         # check enable a napp
         api_url = KYTOS_API+'/core/napps/kytos/mef_eline/enable'
         response = requests.get(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         api_url = KYTOS_API+'/core/napps_enabled/'
         response = requests.get(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         data = response.json()
         assert set([tuple(lst) for lst in data['napps']]) == set(expected_napps)

--- a/tests/test_e2e_05_topology.py
+++ b/tests/test_e2e_05_topology.py
@@ -61,7 +61,7 @@ class TestE2ETopology:
                  '00:00:00:00:00:00:00:03:4294967294'],
         }
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         assert 'topology' in data
         assert 'switches' in data['topology']
         assert len(data['topology']['switches']) == 3
@@ -84,7 +84,7 @@ class TestE2ETopology:
         response = requests.get(api_url)
         data = response.json()
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         assert 'switches' in data
         assert len(data['switches']) == 3
         assert '00:00:00:00:00:00:00:01' in data['switches']
@@ -109,7 +109,7 @@ class TestE2ETopology:
         # Enable the switches
         api_url = KYTOS_API + '/topology/v3/switches/%s/enable' % switch_id
         response = requests.post(api_url)
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
 
         self.restart()
 
@@ -143,7 +143,7 @@ class TestE2ETopology:
         # Disable the switch
         api_url = KYTOS_API + '/topology/v3/switches/%s/disable' % switch_id
         response = requests.post(api_url)
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
 
         self.restart()
 
@@ -169,7 +169,7 @@ class TestE2ETopology:
         key = next(iter(payload))
         api_url = KYTOS_API + '/topology/v3/switches/%s/metadata' % switch_id
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
 
         self.restart()
 
@@ -183,7 +183,7 @@ class TestE2ETopology:
         # Delete the switch metadata
         api_url = KYTOS_API + '/topology/v3/switches/%s/metadata/%s' % (switch_id, key)
         response = requests.delete(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         self.restart()
 
@@ -213,7 +213,7 @@ class TestE2ETopology:
         # Enable the interface
         api_url = KYTOS_API + '/topology/v3/interfaces/%s/enable' % interface_id
         response = requests.post(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         self.restart()
 
@@ -243,7 +243,7 @@ class TestE2ETopology:
         # Enabling all the interfaces
         api_url = KYTOS_API + '/topology/v3/interfaces/switch/%s/enable' % switch_id
         response = requests.post(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         self.restart()
 
@@ -258,7 +258,7 @@ class TestE2ETopology:
         # Disabling all the interfaces
         api_url = KYTOS_API + '/topology/v3/interfaces/switch/%s/disable' % switch_id
         response = requests.post(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         self.restart()
 
@@ -283,7 +283,7 @@ class TestE2ETopology:
         # Enable the interface
         api_url = KYTOS_API + '/topology/v3/interfaces/%s/enable' % interface_id
         response = requests.post(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         self.restart()
 
@@ -296,7 +296,7 @@ class TestE2ETopology:
         # Disable the interface and check if the interface is really disabled
         api_url = KYTOS_API + '/topology/v3/interfaces/%s/disable' % interface_id
         response = requests.post(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         self.restart()
 
@@ -319,7 +319,7 @@ class TestE2ETopology:
         # Enabling all the interfaces
         api_url = KYTOS_API + '/topology/v3/interfaces/switch/%s/enable' % switch_id
         response = requests.post(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         self.restart()
 
@@ -349,7 +349,7 @@ class TestE2ETopology:
 
         api_url = KYTOS_API + '/topology/v3/interfaces/%s/metadata' % interface_id
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
 
         self.restart()
 
@@ -363,7 +363,7 @@ class TestE2ETopology:
         # Delete the interface metadata
         api_url = KYTOS_API + '/topology/v3/interfaces/%s/metadata/%s' % (interface_id, key)
         response = requests.delete(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         self.restart()
 
@@ -389,7 +389,7 @@ class TestE2ETopology:
         response = requests.get(api_url)
         data = response.json()
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         assert len(data['links']) == 0
 
         # Need to enable the switches and ports first
@@ -398,11 +398,11 @@ class TestE2ETopology:
 
             api_url = KYTOS_API + '/topology/v3/switches/%s/enable' % sw
             response = requests.post(api_url)
-            assert response.status_code == 201
+            assert response.status_code == 201, response.text
 
             api_url = KYTOS_API + '/topology/v3/interfaces/switch/%s/enable' % sw
             response = requests.post(api_url)
-            assert response.status_code == 200
+            assert response.status_code == 200, response.text
 
         self.restart()
 
@@ -422,7 +422,7 @@ class TestE2ETopology:
 
         api_url = KYTOS_API + '/topology/v3/links/%s/enable' % link_id1
         response = requests.post(api_url)
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
 
         self.restart()
 
@@ -449,7 +449,7 @@ class TestE2ETopology:
         response = requests.get(api_url)
         data = response.json()
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         assert len(data['links']) == 0
 
         # enable the links (need to enable the switches and ports first)
@@ -458,11 +458,11 @@ class TestE2ETopology:
 
             api_url = KYTOS_API + '/topology/v3/switches/%s/enable' % sw
             response = requests.post(api_url)
-            assert response.status_code == 201
+            assert response.status_code == 201, response.text
 
             api_url = KYTOS_API + '/topology/v3/interfaces/switch/%s/enable' % sw
             response = requests.post(api_url)
-            assert response.status_code == 200
+            assert response.status_code == 200, response.text
 
         self.restart()
 
@@ -482,7 +482,7 @@ class TestE2ETopology:
 
         api_url = KYTOS_API + '/topology/v3/links/%s/enable' % link_id1
         response = requests.post(api_url)
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
 
         # check if the links are now enabled
         api_url = KYTOS_API + '/topology/v3/links'
@@ -506,7 +506,7 @@ class TestE2ETopology:
         # disable the link
         api_url = KYTOS_API + '/topology/v3/links/%s/disable' % link_id1
         response = requests.post(api_url)
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
 
         # restart kytos and check if the links are still enabled
         self.net.start_controller(clean_config=False)
@@ -539,11 +539,11 @@ class TestE2ETopology:
 
             api_url = KYTOS_API + '/topology/v3/switches/%s/enable' % sw
             response = requests.post(api_url)
-            assert response.status_code == 201
+            assert response.status_code == 201, response.text
 
             api_url = KYTOS_API + '/topology/v3/interfaces/switch/%s/enable' % sw
             response = requests.post(api_url)
-            assert response.status_code == 200
+            assert response.status_code == 200, response.text
 
         self.restart()
 
@@ -561,7 +561,7 @@ class TestE2ETopology:
         # Enable the link_id
         api_url = KYTOS_API + '/topology/v3/links/%s/enable' % link_id1
         response = requests.post(api_url)
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
 
         self.restart()
 
@@ -571,7 +571,7 @@ class TestE2ETopology:
 
         api_url = KYTOS_API + '/topology/v3/links/%s/metadata' % link_id1
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
 
         self.restart()
 
@@ -585,7 +585,7 @@ class TestE2ETopology:
         # Delete the link metadata
         api_url = KYTOS_API + '/topology/v3/links/%s/metadata/%s' % (link_id1, key)
         response = requests.delete(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         self.restart()
 
@@ -606,7 +606,7 @@ class TestE2ETopology:
         response = requests.get(api_url)
         data = response.json()
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         assert data['switches'][switch_id]['enabled'] is False
 
     def test_300_interfaces_disabled_on_clean_start(self):
@@ -630,7 +630,7 @@ class TestE2ETopology:
         api_url = KYTOS_API + '/topology/v3/switches'
         response = requests.get(api_url)
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         data = response.json()
         for switch in data['switches']:
             assert data['switches'][switch]['enabled'] is True
@@ -647,7 +647,7 @@ class TestE2ETopology:
         api_url = KYTOS_API + '/topology/v3/interfaces'
         response = requests.get(api_url)
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         data = response.json()
         for interface in data['interfaces']:
             assert data['interfaces'][interface]['enabled'] is True

--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -68,6 +68,7 @@ class TestE2EMefEline:
         }
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
+        assert response.status_code == 201, response.text
         data = response.json()
         if store:
             self.evcs[vlan_id] = data['circuit_id']
@@ -77,7 +78,7 @@ class TestE2EMefEline:
         """Test if list circuits return 'no circuit stored.'."""
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.get(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         assert response.json() == {}
 
     def test_015_create_evc_intra_switch(self):
@@ -103,7 +104,7 @@ class TestE2EMefEline:
         }
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, json=payload)
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
         data = response.json()
         assert 'circuit_id' in data
         time.sleep(10)
@@ -155,7 +156,7 @@ class TestE2EMefEline:
         }
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
         data = response.json()
         assert 'circuit_id' in data
         time.sleep(10)
@@ -206,7 +207,7 @@ class TestE2EMefEline:
         }
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
         data = response.json()
         assert 'circuit_id' in data
         time.sleep(10)
@@ -255,7 +256,7 @@ class TestE2EMefEline:
         }
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
         data = response.json()
         assert 'circuit_id' in data
         time.sleep(10)
@@ -306,7 +307,7 @@ class TestE2EMefEline:
         }
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
         data = response.json()
         assert 'circuit_id' in data
         evc1 = data['circuit_id']
@@ -328,7 +329,7 @@ class TestE2EMefEline:
         }
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
         data = response.json()
         assert 'circuit_id' in data
         evc2 = data['circuit_id']
@@ -400,7 +401,7 @@ class TestE2EMefEline:
         }
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
         data = response.json()
         assert 'circuit_id' in data
         evc1 = data['circuit_id']
@@ -414,7 +415,7 @@ class TestE2EMefEline:
         # It disables the circuit
         payload = {"enable": False}
         response = requests.patch(api_url + evc1, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         time.sleep(10)
 
         # It verifies EVC's status
@@ -460,7 +461,7 @@ class TestE2EMefEline:
         }
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
         data = response.json()
         assert 'circuit_id' in data
         evc1 = data['circuit_id']
@@ -469,7 +470,7 @@ class TestE2EMefEline:
         # Delete the circuit
         api_url += evc1
         response = requests.delete(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         time.sleep(10)
 
         # try to reuse the vlan id
@@ -488,7 +489,7 @@ class TestE2EMefEline:
         }
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
         data = response.json()
         assert 'circuit_id' in data
         evc2 = data['circuit_id']
@@ -550,7 +551,7 @@ class TestE2EMefEline:
 
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
 
         time.sleep(10)
 
@@ -610,16 +611,16 @@ class TestE2EMefEline:
 
         # Delete the circuit
         response = requests.delete(api_url + evc1)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         time.sleep(10)
 
         response = requests.get(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         data = response.json()
         assert evc1 not in data
 
         response = requests.get(api_url, params={'archived': True})
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         data = response.json()
         assert evc1 in data
         assert data[evc1]['archived'] is True
@@ -663,7 +664,7 @@ class TestE2EMefEline:
                 }
                 api_url = KYTOS_API + '/mef_eline/v2/evc/'
                 response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-                assert response.status_code == 201
+                assert response.status_code == 201, response.text
                 data = response.json()
                 assert 'circuit_id' in data
                 evcs[i] = data['circuit_id']
@@ -678,7 +679,7 @@ class TestE2EMefEline:
                 evc_id = evcs[vid]
                 api_url = KYTOS_API + '/mef_eline/v2/evc/' + evc_id
                 response = requests.get(api_url)
-                assert response.status_code == 200
+                assert response.status_code == 200, response.text
                 evc = response.json()
                 # should be active
                 assert evc["active"] is True
@@ -694,14 +695,14 @@ class TestE2EMefEline:
                 evc_id = evcs[vid]
                 api_url = KYTOS_API + '/mef_eline/v2/evc/' + evc_id
                 response = requests.delete(api_url)
-                assert response.status_code == 200
+                assert response.status_code == 200, response.text
 
             time.sleep(10)
 
             # make sure the circuits were deleted
             api_url = KYTOS_API + '/mef_eline/v2/evc/'
             response = requests.get(api_url)
-            assert response.status_code == 200
+            assert response.status_code == 200, response.text
             assert response.json() == {}
             flows_s1 = s1.dpctl('dump-flows')
             flows_s2 = s2.dpctl('dump-flows')
@@ -734,7 +735,7 @@ class TestE2EMefEline:
 
             api_url = KYTOS_API + '/mef_eline/v2/evc/' + self.evcs[vid]
             response = requests.get(api_url)
-            assert response.status_code == 200
+            assert response.status_code == 200, response.text
             evc = response.json()
             # should be active
             assert evc["active"] is True
@@ -753,14 +754,14 @@ class TestE2EMefEline:
             evc_id = self.evcs[vid]
             api_url = KYTOS_API + '/mef_eline/v2/evc/' + evc_id
             response = requests.delete(api_url)
-            assert response.status_code == 200
+            assert response.status_code == 200, response.text
 
         time.sleep(10)
 
         # make sure the circuits were deleted
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.get(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         assert response.json() == {}
         flows_s1 = s1.dpctl('dump-flows')
         flows_s2 = s2.dpctl('dump-flows')
@@ -774,7 +775,7 @@ class TestE2EMefEline:
 
         # It verifies EVC's name
         response = requests.get(api_url + evc1)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         data = response.json()
         assert data['name'] == 'Vlan_100'
 
@@ -783,7 +784,7 @@ class TestE2EMefEline:
         # It sets a new name
         response = requests.patch(api_url + evc1, data=json.dumps(payload),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         time.sleep(10)
 
@@ -805,7 +806,7 @@ class TestE2EMefEline:
         # It sets a new interface_id
         response = requests.patch(api_url + evc1, data=json.dumps(payload),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         time.sleep(10)
 
@@ -827,7 +828,7 @@ class TestE2EMefEline:
         # It sets a new interface_id
         response = requests.patch(api_url + evc1, data=json.dumps(payload),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         time.sleep(10)
 
@@ -1003,7 +1004,7 @@ class TestE2EMefEline:
         # It sets a new circuit's primary_path
         response = requests.patch(api_url + evc1, data=json.dumps(payload2),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         time.sleep(10)
 
@@ -1252,7 +1253,7 @@ class TestE2EMefEline:
 
         # Make sure the metadata is initially empty
         response = requests.get(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         data = response.json()
         assert 'metadata' in data
         assert data['metadata'] == {}
@@ -1262,7 +1263,7 @@ class TestE2EMefEline:
         payload = {my_key: "tmp_value", "other": [1, 2, 3]}
 
         response = requests.post(api_url, json=payload)
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
 
         # Make sure the metadata was inserted
         response = requests.get(api_url)
@@ -1279,7 +1280,7 @@ class TestE2EMefEline:
 
         # Delete the evc metadata
         response = requests.delete(api_url + '/' + my_key)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         # Make sure the metadata was deleted
         response = requests.get(api_url)

--- a/tests/test_e2e_11_mef_eline.py
+++ b/tests/test_e2e_11_mef_eline.py
@@ -311,4 +311,4 @@ class TestE2EMefEline:
 
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text

--- a/tests/test_e2e_12_mef_eline.py
+++ b/tests/test_e2e_12_mef_eline.py
@@ -60,7 +60,7 @@ class TestE2EMefEline:
         }
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, json=payload)
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
 
         data = response.json()
 
@@ -78,7 +78,7 @@ class TestE2EMefEline:
         api_url = KYTOS_API + '/mef_eline/v2/evc/' + circuit_id
         response = requests.patch(api_url, json=payload)
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         return
 
@@ -103,7 +103,7 @@ class TestE2EMefEline:
         # create circuit schedule
         api_url = KYTOS_API + '/mef_eline/v2/evc/schedule'
         response = requests.post(api_url, json=payload)
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
 
         # waiting some time to trigger the scheduler
         sched_wait = 62
@@ -112,7 +112,7 @@ class TestE2EMefEline:
         # Verify if the circuit is enabled 
         api_url = KYTOS_API + '/mef_eline/v2/evc/' + disabled_circuit_id
         response = requests.get(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         json = response.json()
         assert json.get("enabled") is True
@@ -146,7 +146,7 @@ class TestE2EMefEline:
         # create circuit schedule
         api_url = KYTOS_API + '/mef_eline/v2/evc/schedule'
         response = requests.post(api_url, json=payload)
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
 
         # waiting some time to trigger the scheduler
         sched_wait = 62
@@ -155,7 +155,7 @@ class TestE2EMefEline:
         # Verify if the circuit is enabled 
         api_url = KYTOS_API + '/mef_eline/v2/evc/' + disabled_circuit_id
         response = requests.get(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         json = response.json()
         assert json.get("enabled") is True
@@ -178,12 +178,12 @@ class TestE2EMefEline:
         # Create circuit schedule
         api_url = KYTOS_API + '/mef_eline/v2/evc/schedule'
         response = requests.post(api_url, json=payload)
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
 
         # Verify the list of schedules
         api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/'
         response = requests.get(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         data = response.json()[0]
         assert data.get("circuit_id") == circuit_id
@@ -198,17 +198,17 @@ class TestE2EMefEline:
         # Delete circuit schedule
         api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/' + schedule_id
         response = requests.delete(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         # Verify if the circuit schedule does not exist
         api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/' + schedule_id
         response = requests.get(api_url)
-        assert response.status_code == 405
+        assert response.status_code == 405, response.text
 
         # Verify the list of schedules
         api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/'
         response = requests.get(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         data = response.json()
         assert data == []
@@ -229,7 +229,7 @@ class TestE2EMefEline:
         api_url = KYTOS_API + '/mef_eline/v2/evc/schedule'
         response = requests.post(api_url, json=payload)
         json = response.json()
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
 
         # Get schedule ID
         schedule_id = json.get("id")
@@ -248,7 +248,7 @@ class TestE2EMefEline:
         # patch circuit schedule
         api_url = KYTOS_API + '/mef_eline/v2/evc/schedule/' + schedule_id
         response = requests.patch(api_url, json=payload)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         # waiting to trigger the scheduler
         sched_wait = 62
@@ -259,7 +259,7 @@ class TestE2EMefEline:
         response = requests.get(api_url)
         json = response.json()
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         assert json.get("enabled") is True
 
         frequency = json.get("circuit_scheduler")[0].get("frequency")
@@ -271,7 +271,7 @@ class TestE2EMefEline:
         # List all the circuits stored
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.get(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         data = response.json()
         key = next(iter(data))
         assert data is not {}
@@ -304,7 +304,7 @@ class TestE2EMefEline:
 
         # It tries to set a new circuit's start_date
         response = requests.patch(api_url + circuit_id, json=payload)
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
         time.sleep(10)
 
@@ -347,7 +347,7 @@ class TestE2EMefEline:
 
         # It sets a new circuit's start_date
         response = requests.patch(api_url + schedule_id, json=payload2)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         time.sleep(10)
 
@@ -363,7 +363,7 @@ class TestE2EMefEline:
         # Delete the circuit
         api_url = KYTOS_API + '/mef_eline/v2/evc/' + circuit_id
         response = requests.delete(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         time.sleep(10)
 
@@ -371,7 +371,7 @@ class TestE2EMefEline:
         # listing all the circuits stored
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.get(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         data = response.json()
         assert data == {}
 

--- a/tests/test_e2e_13_mef_eline.py
+++ b/tests/test_e2e_13_mef_eline.py
@@ -84,7 +84,7 @@ class TestE2EMefEline:
         # It sets a new circuit's primary_path
         response = requests.patch(api_url + evc1 + "A", data=json.dumps(payload),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 404
+        assert response.status_code == 404, response.text
 
         # It verifies EVC's data
         response = requests.get(api_url + evc1)
@@ -102,7 +102,7 @@ class TestE2EMefEline:
         # It tries to setting up a new uni_a
         response = requests.patch(api_url + evc1, data=json.dumps(payload),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_015_patch_an_inconsistent_uni_a(self):
         """ No existing switch """
@@ -119,7 +119,7 @@ class TestE2EMefEline:
         # It tries to setting up a new uni_a
         response = requests.patch(api_url + evc1, data=json.dumps(payload),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_020_patch_an_inconsistent_uni_a(self):
         """ Valid switch but invalid Interface ID """
@@ -136,7 +136,7 @@ class TestE2EMefEline:
         # It tries to setting up a new uni_a
         response = requests.patch(api_url + evc1, data=json.dumps(payload),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_025_patch_an_inconsistent_uni_a(self):
         """ Valid switch, valid Interface ID, but invalid tag_type (string) """
@@ -157,7 +157,7 @@ class TestE2EMefEline:
         # It tries to setting up a new uni_a
         response = requests.patch(api_url + evc1, data=json.dumps(payload),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     @pytest.mark.xfail
     def test_030_patch_an_inconsistent_uni_a(self):
@@ -179,7 +179,7 @@ class TestE2EMefEline:
         # It tries to setting up a new uni_a
         response = requests.patch(api_url + evc1, data=json.dumps(payload),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     @pytest.mark.xfail
     def test_035_patch_an_inconsistent_uni_a(self):
@@ -201,7 +201,7 @@ class TestE2EMefEline:
         # It tries to setting up a new uni_a
         response = requests.patch(api_url + evc1, data=json.dumps(payload),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     @pytest.mark.xfail
     def test_040_patch_an_inconsistent_uni_a(self):
@@ -223,7 +223,7 @@ class TestE2EMefEline:
         # It tries to setting up a new uni_a
         response = requests.patch(api_url + evc1, data=json.dumps(payload),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     @pytest.mark.xfail
     def test_045_patch_an_inconsistent_uni_a(self):
@@ -245,7 +245,7 @@ class TestE2EMefEline:
         # It tries to setting up a new uni_a
         response = requests.patch(api_url + evc1, data=json.dumps(payload),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_050_patch_an_inconsistent_uni_a(self):
         """ Valid switch, valid Interface ID, valid tag_type, but invalid tag_name """
@@ -266,7 +266,7 @@ class TestE2EMefEline:
         # It tries to setting up a new uni_a
         response = requests.patch(api_url + evc1, data=json.dumps(payload),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     # TODO
     """ This test should change the Vlan range and modify it to a plan value outside that range """
@@ -284,7 +284,7 @@ class TestE2EMefEline:
         # It tries to setting up a new uni_z
         response = requests.patch(api_url + evc1, data=json.dumps(payload),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_065_patch_an_inconsistent_uni_z(self):
         """ No existing switch """
@@ -301,7 +301,7 @@ class TestE2EMefEline:
         # It tries to setting up a new uni_z
         response = requests.patch(api_url + evc1, data=json.dumps(payload),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_070_patch_an_inconsistent_uni_z(self):
         """ Valid switch but invalid Interface ID """
@@ -318,7 +318,7 @@ class TestE2EMefEline:
         # It tries to setting up a new uni_z
         response = requests.patch(api_url + evc1, data=json.dumps(payload),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_075_patch_an_inconsistent_uni_z(self):
         """ Valid switch, valid Interface ID, but invalid tag_type (string) """
@@ -339,7 +339,7 @@ class TestE2EMefEline:
         # It tries to setting up a new uni_z
         response = requests.patch(api_url + evc1, data=json.dumps(payload),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     @pytest.mark.xfail
     def test_080_patch_an_inconsistent_uni_z(self):
@@ -361,7 +361,7 @@ class TestE2EMefEline:
         # It tries to setting up a new uni_z
         response = requests.patch(api_url + evc1, data=json.dumps(payload),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     @pytest.mark.xfail
     def test_085_patch_an_inconsistent_uni_z(self):
@@ -383,7 +383,7 @@ class TestE2EMefEline:
         # It tries to setting up a new uni_z
         response = requests.patch(api_url + evc1, data=json.dumps(payload),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     @pytest.mark.xfail
     def test_090_patch_an_inconsistent_uni_z(self):
@@ -405,7 +405,7 @@ class TestE2EMefEline:
         # It tries to setting up a new uni_z
         response = requests.patch(api_url + evc1, data=json.dumps(payload),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     @pytest.mark.xfail
     def test_095_patch_an_inconsistent_uni_z(self):
@@ -427,7 +427,7 @@ class TestE2EMefEline:
         # It tries to setting up a new uni_z
         response = requests.patch(api_url + evc1, data=json.dumps(payload),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_100_patch_an_inconsistent_uni_z(self):
         """ Valid switch, valid Interface ID, valid tag_type, but invalid tag_name """
@@ -448,7 +448,7 @@ class TestE2EMefEline:
         # It tries to setting up a new uni_z
         response = requests.patch(api_url + evc1, data=json.dumps(payload),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     """It is returning Response [200], should be 400"""
     @pytest.mark.xfail
@@ -483,7 +483,7 @@ class TestE2EMefEline:
         # It sets a new circuit's primary_path
         response = requests.patch(api_url + evc1, data=json.dumps(payload2),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
         time.sleep(10)
 
         # It verifies EVC's data
@@ -531,7 +531,7 @@ class TestE2EMefEline:
         # It sets a new circuit's primary_path
         response = requests.patch(api_url + evc1, data=json.dumps(payload2),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
         time.sleep(10)
 
         # It verifies EVC's data
@@ -576,7 +576,7 @@ class TestE2EMefEline:
         # It sets a new circuit's primary_path
         response = requests.patch(api_url + evc1, data=json.dumps(payload),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
         time.sleep(10)
 
@@ -625,7 +625,7 @@ class TestE2EMefEline:
         # It sets a new circuit's primary_path
         response = requests.patch(api_url + evc1, data=json.dumps(payload2),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
         time.sleep(10)
 
         # It verifies EVC's data
@@ -677,7 +677,7 @@ class TestE2EMefEline:
         # It sets a new circuit's primary_path
         response = requests.patch(api_url + evc1, data=json.dumps(payload2),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
         time.sleep(10)
 
         # It verifies EVC's data
@@ -725,7 +725,7 @@ class TestE2EMefEline:
         # It sets a new circuit's primary_path
         response = requests.patch(api_url + evc1, data=json.dumps(payload2),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
         time.sleep(10)
 
         # It verifies EVC's data
@@ -773,7 +773,7 @@ class TestE2EMefEline:
         # It sets a new circuit's primary_path
         response = requests.patch(api_url + evc1, data=json.dumps(payload2),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
         time.sleep(10)
 
         # It verifies EVC's data
@@ -827,7 +827,7 @@ class TestE2EMefEline:
         # It sets a new circuit's primary_path
         response = requests.patch(api_url + evc1, data=json.dumps(payload2),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
         time.sleep(10)
 
         # It verifies EVC's data
@@ -881,7 +881,7 @@ class TestE2EMefEline:
         # It sets a new circuit's primary_path
         response = requests.patch(api_url + evc1, data=json.dumps(payload2),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
         time.sleep(10)
 
@@ -914,7 +914,7 @@ class TestE2EMefEline:
         # It sets a new circuit's creation_time
         response = requests.patch(api_url + evc1, data=json.dumps(payload),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
         time.sleep(10)
 
@@ -933,7 +933,7 @@ class TestE2EMefEline:
         # It sets a new circuit's creation_time
         response = requests.patch(api_url + evc1, data=json.dumps(payload),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
         # It verifies EVC's data
         response = requests.get(api_url + evc1)
@@ -954,7 +954,7 @@ class TestE2EMefEline:
         # It sets a new circuit's creation_time
         response = requests.patch(api_url + evc1, data=json.dumps(payload),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
         # It verifies EVC's data
         response = requests.get(api_url + evc1)
@@ -1005,7 +1005,7 @@ class TestE2EMefEline:
         # It sets a new circuit's creation_time
         response = requests.patch(api_url + evc1, data=json.dumps(payload2),
                                   headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
         time.sleep(10)
 
@@ -1022,14 +1022,14 @@ class TestE2EMefEline:
         response = requests.post(api_url, data=json.dumps(payload),
                                  headers={'Content-type': 'application/json'})
 
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_175_post_empty_json(self):
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         payload = {}
         response = requests.post(api_url, data=json.dumps(payload),
                                  headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_180_post_unknown_port_on_interface(self):
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
@@ -1047,7 +1047,7 @@ class TestE2EMefEline:
 
         response = requests.post(api_url, data=json.dumps(payload1),
                                  headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_185_post_unknown_interface(self):
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
@@ -1065,7 +1065,7 @@ class TestE2EMefEline:
 
         response = requests.post(api_url, data=json.dumps(payload1),
                                  headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_190_post_an_evc_twice(self):
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
@@ -1083,11 +1083,11 @@ class TestE2EMefEline:
 
         response = requests.post(api_url, data=json.dumps(payload1),
                                  headers={'Content-type': 'application/json'})
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
 
         response = requests.post(api_url, data=json.dumps(payload1),
                                  headers={'Content-type': 'application/json'})
-        assert response.status_code == 409
+        assert response.status_code == 409, response.text
 
     def test_195_get_unknown_circuit(self):
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
@@ -1095,7 +1095,7 @@ class TestE2EMefEline:
 
         # It verifies EVC's data
         response = requests.get(api_url + evc1 + "A")
-        assert response.status_code == 404
+        assert response.status_code == 404, response.text
 
     def test_200_post_on_dynamic_backup_path_and_backup_path(self):
         payload = {
@@ -1118,7 +1118,7 @@ class TestE2EMefEline:
 
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_205_post_on_false_dynamic_backup_path_and_empty_primary_path(self):
         payload = {
@@ -1138,7 +1138,7 @@ class TestE2EMefEline:
 
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_210_post_on_false_dynamic_backup_path_and_none_primary_path(self):
         payload = {
@@ -1157,7 +1157,7 @@ class TestE2EMefEline:
 
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_215_post_on_none_dynamic_backup_path_and_empty_primary_path(self):
         payload = {
@@ -1176,7 +1176,7 @@ class TestE2EMefEline:
 
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_220_post_on_none_dynamic_backup_path_and_none_primary_path(self):
         payload = {
@@ -1194,6 +1194,6 @@ class TestE2EMefEline:
 
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     # TODO tests over primary_links and backup_links

--- a/tests/test_e2e_15_maintenance.py
+++ b/tests/test_e2e_15_maintenance.py
@@ -73,7 +73,7 @@ class TestE2EMaintenance:
         # Gets the maintenance schemas
         api_url = KYTOS_API + '/maintenance/'
         response = requests.get(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         json_data = response.json()
         assert json_data == []
 
@@ -104,7 +104,7 @@ class TestE2EMaintenance:
         # Creates a new maintenance window
         api_url = KYTOS_API + '/maintenance'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
         data = response.json()
         assert 'mw_id' in data
 
@@ -178,7 +178,7 @@ class TestE2EMaintenance:
         # Creates a new maintenance window
         api_url = KYTOS_API + '/maintenance'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_020_create_mw_on_switch_should_fail_items_empty(self):
         """Tests to create maintenance with the wrong payload
@@ -206,7 +206,7 @@ class TestE2EMaintenance:
         # Creates a new maintenance window
         api_url = KYTOS_API + '/maintenance'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_025_create_mw_on_switch_should_fail_no_items_field_on_payload(self):
         """Tests to create maintenance with the wrong payload
@@ -233,7 +233,7 @@ class TestE2EMaintenance:
         # Creates a new maintenance window
         api_url = KYTOS_API + '/maintenance'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_030_create_mw_on_switch_should_fail_payload_empty(self):
         """Tests to create maintenance with the wrong payload
@@ -250,7 +250,7 @@ class TestE2EMaintenance:
         # Creates a new maintenance window
         api_url = KYTOS_API + '/maintenance'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-        assert response.status_code == 415
+        assert response.status_code == 415, response.text
 
     def test_035_create_mw_on_switch_and_patch_new_end(self):
         """Tests the maintenance window data update
@@ -282,7 +282,7 @@ class TestE2EMaintenance:
         # Creates a new maintenance window
         api_url = KYTOS_API + '/maintenance'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
         data = response.json()
         assert 'mw_id' in data
 
@@ -293,7 +293,7 @@ class TestE2EMaintenance:
         # Gets the maintenance schema
         api_url = KYTOS_API + '/maintenance/' + mw_id
         response = requests.get(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         json_data = response.json()
         assert json_data['id'] == mw_id
 
@@ -557,7 +557,7 @@ class TestE2EMaintenance:
         # Creates a new maintenance window
         api_url = KYTOS_API + '/maintenance'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
         data = response.json()
         assert 'mw_id' in data
 
@@ -568,7 +568,7 @@ class TestE2EMaintenance:
         # Gets the maintenance schema
         api_url = KYTOS_API + '/maintenance/' + mw_id
         response = requests.get(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         json_data = response.json()
         assert json_data['id'] == mw_id
 
@@ -619,7 +619,7 @@ class TestE2EMaintenance:
         # Creates a new maintenance window
         api_url = KYTOS_API + '/maintenance'
         response = requests.post(api_url, data=json.dumps(payload), headers={'Content-type': 'application/json'})
-        assert response.status_code == 201
+        assert response.status_code == 201, response.text
         data = response.json()
         assert 'mw_id' in data
 
@@ -630,7 +630,7 @@ class TestE2EMaintenance:
         # Gets the maintenance schema
         api_url = KYTOS_API + '/maintenance/' + mw_id
         response = requests.get(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         json_data = response.json()
         assert json_data['id'] == mw_id
 
@@ -847,7 +847,7 @@ class TestE2EMaintenance:
         # Gets the maintenance schema
         api_url = KYTOS_API + '/maintenance/' + mw_id
         response = requests.get(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         json_data = response.json()
         assert json_data['id'] == mw_id
 
@@ -976,7 +976,7 @@ class TestE2EMaintenance:
         # Gets the maintenance schema
         api_url = KYTOS_API + '/maintenance/' + mw_id
         response = requests.get(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         json_data = response.json()
         assert json_data['id'] == mw_id
 
@@ -1005,7 +1005,7 @@ class TestE2EMaintenance:
         # extend the maintenance window information
         api_url = KYTOS_API + '/maintenance/' + mw_id + '/extend'
         response = requests.patch(api_url, data=json.dumps(payload2), headers={'Content-type': 'application/json'})
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         # Waits to the time that the MW should be ended but instead will be running (extended)
         time.sleep(mw_duration + 5)
@@ -1073,7 +1073,7 @@ class TestE2EMaintenance:
         # extend the maintenance window information
         api_url = KYTOS_API + '/maintenance/' + mw_id + '/extend'
         response = requests.patch(api_url, data=json.dumps(payload2), headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_110_extend_unknown_mw_on_switch_should_fail(self):
         self.restart_and_create_circuit()
@@ -1086,7 +1086,7 @@ class TestE2EMaintenance:
         # extend the maintenance window information
         api_url = KYTOS_API + '/maintenance/' + mw_id + '/extend'
         response = requests.patch(api_url, data=json.dumps(payload2), headers={'Content-type': 'application/json'})
-        assert response.status_code == 404
+        assert response.status_code == 404, response.text
 
     def test_115_extend_running_mw_on_switch_under_unknown_tag_should_fail(self):
         self.restart_and_create_circuit()
@@ -1124,7 +1124,7 @@ class TestE2EMaintenance:
         # extend the maintenance window information
         api_url = KYTOS_API + '/maintenance/' + mw_id + '/extend'
         response = requests.patch(api_url, data=json.dumps(payload2), headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_120_extend_ended_mw_on_switch_should_fail(self):
         self.restart_and_create_circuit()
@@ -1162,4 +1162,4 @@ class TestE2EMaintenance:
         # extend the maintenance window information
         api_url = KYTOS_API + '/maintenance/' + mw_id + '/extend'
         response = requests.patch(api_url, data=json.dumps(payload2), headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text

--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -59,7 +59,7 @@ class TestE2EFlowManager:
         api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
         response = requests.post(api_url, data=json.dumps(payload),
                                  headers={'Content-type': 'application/json'})
-        assert response.status_code == 202
+        assert response.status_code == 202, response.text
         data = response.json()
         assert 'FlowMod Messages Sent' in data['response']
 
@@ -117,7 +117,7 @@ class TestE2EFlowManager:
         time.sleep(10)
 
         response = requests.get(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         data = response.json()
         assert len(data[switch_id]["flows"]) == 2
         assert data[switch_id]["flows"][1]["instructions"][0]["instruction_type"] == "apply_actions"
@@ -153,7 +153,7 @@ class TestE2EFlowManager:
         api_url = KYTOS_API + '/flow_manager/v2/flows'
         response = requests.post(api_url, data=json.dumps(payload),
                                  headers={'Content-type': 'application/json'})
-        assert response.status_code == 202
+        assert response.status_code == 202, response.text
         data = response.json()
         assert 'FlowMod Messages Sent' in data['response']
 
@@ -206,7 +206,7 @@ class TestE2EFlowManager:
         api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
         response = requests.delete(api_url, data=json.dumps(payload),
                                    headers={'Content-type': 'application/json'})
-        assert response.status_code == 202
+        assert response.status_code == 202, response.text
         data = response.json()
         assert 'FlowMod Messages Sent' in data['response']
 
@@ -258,7 +258,7 @@ class TestE2EFlowManager:
         api_url = KYTOS_API + '/flow_manager/v2/flows'
         response = requests.delete(api_url, data=json.dumps(payload),
                                    headers={'Content-type': 'application/json'})
-        assert response.status_code == 202
+        assert response.status_code == 202, response.text
         data = response.json()
         assert 'FlowMod Messages Sent' in data['response']
 
@@ -490,7 +490,7 @@ class TestE2EFlowManager:
     def test_080_retrieve_flows(self):
         api_url = KYTOS_API + '/flow_manager/v2/flows'
         response = requests.get(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         data = response.json()
         assert len(data) == 3
         assert "00:00:00:00:00:00:00:01" in data.keys()

--- a/tests/test_e2e_21_flow_manager.py
+++ b/tests/test_e2e_21_flow_manager.py
@@ -59,7 +59,7 @@ class TestE2EFlowManager:
         api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
         response = requests.post(api_url, data=json.dumps(payload),
                                  headers={'Content-type': 'application/json'})
-        assert response.status_code == 202
+        assert response.status_code == 202, response.text
         data = response.json()
         assert 'FlowMod Messages Sent' in data['response']
 
@@ -112,7 +112,7 @@ class TestE2EFlowManager:
         api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
         response = requests.post(api_url, data=json.dumps(payload),
                                  headers={'Content-type': 'application/json'})
-        assert response.status_code == 202
+        assert response.status_code == 202, response.text
         data = response.json()
         assert 'FlowMod Messages Sent' in data['response']
 

--- a/tests/test_e2e_22_flow_manager.py
+++ b/tests/test_e2e_22_flow_manager.py
@@ -58,7 +58,7 @@ class TestE2EFlowManager:
         api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:05'
         response = requests.post(api_url, data=json.dumps(payload),
                                  headers={'Content-type': 'application/json'})
-        assert response.status_code == 404
+        assert response.status_code == 404, response.text
 
     def test_010_install_flow_should_fail(self):
         """Tests if the flow installation process specifying an empty
@@ -69,7 +69,7 @@ class TestE2EFlowManager:
         api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
         response = requests.post(api_url, data=json.dumps(payload),
                                  headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_015_install_flow_should_fail(self):
         """Tests if the flow installation process specifying an empty
@@ -83,7 +83,7 @@ class TestE2EFlowManager:
         api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
         response = requests.post(api_url, data=json.dumps(payload),
                                  headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_020_install_flow_should_fail(self):
         """Tests if the flow installation process specifying an empty
@@ -100,7 +100,7 @@ class TestE2EFlowManager:
         api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
         response = requests.post(api_url, data=json.dumps(payload),
                                  headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_025_retrieve_flow_from_non_existent_switch_should_fail(self):
         """Tests if the flow retrieving process of an invalid
@@ -111,7 +111,7 @@ class TestE2EFlowManager:
         # It tries to get a flow that does not exist
         api_url = KYTOS_API + '/flow_manager/v2/flows/' + switch_id
         response = requests.get(api_url)
-        assert response.status_code == 404
+        assert response.status_code == 404, response.text
 
     def test_030_install_flows_should_fail(self):
         """Tests if the flow installation process specifying an
@@ -122,7 +122,7 @@ class TestE2EFlowManager:
         api_url = KYTOS_API + '/flow_manager/v2/flows'
         response = requests.post(api_url, data=json.dumps(payload),
                                  headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_035_install_flows_should_fail(self):
         """Tests if the flow installation process specifying an empty
@@ -136,7 +136,7 @@ class TestE2EFlowManager:
         api_url = KYTOS_API + '/flow_manager/v2/flows'
         response = requests.post(api_url, data=json.dumps(payload),
                                  headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_040_install_flows_should_fail(self):
         """Tests if the flow installation process specifying an empty
@@ -153,7 +153,7 @@ class TestE2EFlowManager:
         api_url = KYTOS_API + '/flow_manager/v2/flows'
         response = requests.post(api_url, data=json.dumps(payload),
                                  headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_045_delete_flow_on_non_existent_switch_should_fail(self):
         """Tests if the flow deletion process specifying an
@@ -182,7 +182,7 @@ class TestE2EFlowManager:
         api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:05'
         response = requests.delete(api_url, data=json.dumps(payload),
                                    headers={'Content-type': 'application/json'})
-        assert response.status_code == 404
+        assert response.status_code == 404, response.text
 
     def test_050_delete_flow_should_fail(self):
         """Tests if the flow deletion process specifying an
@@ -194,7 +194,7 @@ class TestE2EFlowManager:
         api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
         response = requests.delete(api_url, data=json.dumps(payload),
                                    headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_055_delete_flow_should_fail(self):
         """Tests if the flow deletion process specifying an empty
@@ -209,7 +209,7 @@ class TestE2EFlowManager:
         api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
         response = requests.delete(api_url, data=json.dumps(payload),
                                    headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_060_delete_flow_should_fail(self):
         """Tests if the flow deletion process specifying an an empty
@@ -227,7 +227,7 @@ class TestE2EFlowManager:
         api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
         response = requests.delete(api_url, data=json.dumps(payload),
                                    headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_065_delete_flows_should_fail(self):
         """Tests if the flow deletion process specifying an
@@ -239,7 +239,7 @@ class TestE2EFlowManager:
         api_url = KYTOS_API + '/flow_manager/v2/flows'
         response = requests.delete(api_url, data=json.dumps(payload),
                                    headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_070_delete_flows_should_fail(self):
         """Tests if the flow deletion process specifying an empty flow
@@ -254,7 +254,7 @@ class TestE2EFlowManager:
         api_url = KYTOS_API + '/flow_manager/v2/flows'
         response = requests.delete(api_url, data=json.dumps(payload),
                                    headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text
 
     def test_075_delete_flows_should_fail(self):
         """Tests if the flow deletion process specifying an empty flow
@@ -272,4 +272,4 @@ class TestE2EFlowManager:
         api_url = KYTOS_API + '/flow_manager/v2/flows'
         response = requests.delete(api_url, data=json.dumps(payload),
                                    headers={'Content-type': 'application/json'})
-        assert response.status_code == 400
+        assert response.status_code == 400, response.text

--- a/tests/test_e2e_23_flow_manager.py
+++ b/tests/test_e2e_23_flow_manager.py
@@ -94,7 +94,7 @@ class TestE2EFlowManager:
         api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
         response = requests.post(api_url, data=json.dumps(payload),
                                  headers={'Content-type': 'application/json'})
-        assert response.status_code == 202
+        assert response.status_code == 202, response.text
         data = response.json()
         assert 'FlowMod Messages Sent' in data['response']
 
@@ -186,7 +186,7 @@ class TestE2EFlowManager:
         api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
         response = requests.post(api_url, data=json.dumps(payload),
                                  headers={'Content-type': 'application/json'})
-        assert response.status_code == 202
+        assert response.status_code == 202, response.text
         data = response.json()
         assert 'FlowMod Messages Sent' in data['response']
 
@@ -278,7 +278,7 @@ class TestE2EFlowManager:
         api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
         response = requests.post(api_url, data=json.dumps(payload),
                                  headers={'Content-type': 'application/json'})
-        assert response.status_code == 202
+        assert response.status_code == 202, response.text
         data = response.json()
         assert 'FlowMod Messages Sent' in data['response']
 
@@ -1064,7 +1064,7 @@ class TestE2EFlowManager:
         response = requests.post(api_url, data=json.dumps(payload),
                                  headers = {'Content-type': 'application/json'})
 
-        assert response.status_code == 202
+        assert response.status_code == 202, response.text
         data = response.json()
         assert 'FlowMod Messages Sent' in data['response']
 

--- a/tests/test_e2e_30_of_lldp.py
+++ b/tests/test_e2e_30_of_lldp.py
@@ -40,13 +40,13 @@ class TestE2EOfLLDP:
         data = response.json()
         all_interfaces = data.get("interfaces", [])
         response = requests.post(api_url+'disable/', json={"interfaces": all_interfaces})
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
     def test_001_list_interfaces_with_lldp(self):
         """ List interfaces with OF LLDP. """
         api_url = KYTOS_API + '/of_lldp/v1/interfaces/'
         response = requests.get(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         data = response.json()
         assert "interfaces" in data
         # the number of interfaces should match the topology + the OFP_LOCAL port, for the RingTopology it means:
@@ -105,7 +105,7 @@ class TestE2EOfLLDP:
 
         api_url = KYTOS_API + '/of_lldp/v1/interfaces/disable/'
         response = requests.post(api_url, json=payload)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         api_url = KYTOS_API + '/of_lldp/v1/interfaces/'
         response = requests.get(api_url)
@@ -157,7 +157,7 @@ class TestE2EOfLLDP:
 
         api_url = KYTOS_API + '/of_lldp/v1/interfaces/enable/'
         response = requests.post(api_url, json=payload)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         api_url = KYTOS_API + '/of_lldp/v1/interfaces/'
         response = requests.get(api_url)
@@ -189,7 +189,7 @@ class TestE2EOfLLDP:
         default_polling_time = 3
         api_url = KYTOS_API + '/of_lldp/v1/polling_time'
         response = requests.get(api_url)
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
         data = response.json()
         assert "polling_time" in data
         assert data["polling_time"] == default_polling_time
@@ -205,7 +205,7 @@ class TestE2EOfLLDP:
 
         api_url = KYTOS_API + '/of_lldp/v1/polling_time'
         response = requests.post(api_url, json={"polling_time": 1})
-        assert response.status_code == 200
+        assert response.status_code == 200, response.text
 
         response = requests.get(api_url)
         data = response.json()


### PR DESCRIPTION
This PR adds more information to assertions on request/status_code: it adds the response.text. The response.text is quite useful because it may contains more information on why the result is different from what was expected.