### PR TITLE
Add way to force stop Kytos after 5s

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -161,8 +161,12 @@ class NetworkTest:
             #    pid = int(f.read())
             #    os.kill(pid, signal.SIGTERM)
             time.sleep(5)
+            if os.path.exists('/var/run/kytos/kytosd.pid'):
+                raise Exception("Kytos pid still exists.")
         except Exception as e:
-            print("FAIL restarting kytos -- %s" % e)
+            print("FAIL to stop kytos after 5 seconds -- %s. Force stop!" % e)
+            os.system('pkill -9 kytosd')
+            os.system('rm -f /var/run/kytos/kytosd.pid')
 
         if clean_config:
             # TODO: config is defined at NAPPS_DIR/kytos/storehouse/settings.py 


### PR DESCRIPTION
Fixes #112 

This PR adds a way to force Kytos to stop if the shutdown process still leaves the PID file after 5s of shutdown being requested.