### PR TITLE
Sync kytos-init.sh as we have in the CI pipeline and add more info to help troubleshoot

### DIFF
--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -8,7 +8,6 @@ sed -i 's/STATS_INTERVAL = 60/STATS_INTERVAL = 3/g' /var/lib/kytos/napps/kytos/o
 sed -i 's/LINK_UP_TIMER = 10/LINK_UP_TIMER = 1/g' /var/lib/kytos/napps/kytos/topology/settings.py
 sed -i 's/DEPLOY_EVCS_INTERVAL = 60/DEPLOY_EVCS_INTERVAL = 5/g' /var/lib/kytos/napps/kytos/mef_eline/settings.py
 sed -i 's/BOX_RESTORE_TIMER = 0.1/BOX_RESTORE_TIMER = 0.5/' /var/lib/kytos/napps/kytos/flow_manager/settings.py
-sed -i 's/COOKIE_PREFIX = 0xbb/COOKIE_PREFIX = 0xab/g' /var/lib/kytos/napps/kytos/of_lldp/settings.py
 
 # increase logging to facilitate troubleshooting
 kytosd --help >/dev/null 2>&1  ## create configs at /etc/kytos from templates

--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -7,14 +7,16 @@ set -x
 sed -i 's/STATS_INTERVAL = 60/STATS_INTERVAL = 3/g' /var/lib/kytos/napps/kytos/of_core/settings.py
 sed -i 's/LINK_UP_TIMER = 10/LINK_UP_TIMER = 1/g' /var/lib/kytos/napps/kytos/topology/settings.py
 sed -i 's/DEPLOY_EVCS_INTERVAL = 60/DEPLOY_EVCS_INTERVAL = 5/g' /var/lib/kytos/napps/kytos/mef_eline/settings.py
+sed -i 's/BOX_RESTORE_TIMER = 0.1/BOX_RESTORE_TIMER = 0.5/' /var/lib/kytos/napps/kytos/flow_manager/settings.py
+sed -i 's/COOKIE_PREFIX = 0xbb/COOKIE_PREFIX = 0xab/g' /var/lib/kytos/napps/kytos/of_lldp/settings.py
+
+# increase logging to facilitate troubleshooting
+kytosd --help >/dev/null 2>&1  ## create configs at /etc/kytos from templates
 sed -i 's/WARNING/INFO/g' /etc/kytos/logging.ini
 
-test -z "$TESTS" && TESTS=tests/ 
+test -z "$TESTS" && TESTS=tests/
 
-python -m pytest $TESTS
+python -m pytest $TESTS 2>&1 | tee log-e2e-$(date +%Y%m%d%H%M%S)
 
 # only run specific test
 # python -m pytest --timeout=60 tests/test_e2e_10_mef_eline.py::TestE2EMefEline::test_on_primary_path_fail_should_migrate_to_backup
-
-# leave tail running unless it is from Gitlab-CI
-[ -z "$CI_PROJECT_ID" ] && tail -f /dev/null

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ def pytest_terminal_summary(terminalreporter):
     terminalreporter.section('start/stop times', sep='-', bold=True)
     for stat in terminalreporter.stats.values():
         for report in stat:
-            if report.when == 'call' and report.failed and hasattr(report, 'start') and hasattr(report, 'stop'):
+            if hasattr(report, 'failed') and report.failed and report.when == 'call':
                 start = datetime.fromtimestamp(report.start)
                 stop = datetime.fromtimestamp(report.stop)
                 terminalreporter.write_line('{id:20}: {start:%Y-%m-%d,%H:%M:%S.%f} - {stop:%Y-%m-%d,%H:%M:%S.%f}'.format(id=report.nodeid, start=start, stop=stop))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+from datetime import datetime
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    outcome = yield
+    report = outcome.get_result()
+    report.start = call.start
+    report.stop = call.stop
+
+def pytest_terminal_summary(terminalreporter):
+    terminalreporter.ensure_newline()
+    terminalreporter.section('start/stop times', sep='-', bold=True)
+    for stat in terminalreporter.stats.values():
+        for report in stat:
+            if report.when == 'call' and report.failed and hasattr(report, 'start') and hasattr(report, 'stop'):
+                start = datetime.fromtimestamp(report.start)
+                stop = datetime.fromtimestamp(report.stop)
+                terminalreporter.write_line('{id:20}: {start:%Y-%m-%d,%H:%M:%S.%f} - {stop:%Y-%m-%d,%H:%M:%S.%f}'.format(id=report.nodeid, start=start, stop=stop))


### PR DESCRIPTION
This PR adds a few options/configs that we also apply in the CI/CD pipeline. Thus, when running the tests outside of the CI/CD environment one can get the same behavior.

Also, I've added a pytest hook to print start and end time for failed tests. This helps troubleshooting by matching the log entries from the specific time interval of the failed test.