### PR TITLE
[Feature] Updated to use `python3` executable to be compatible with debian_bullseye

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,11 +23,11 @@ for Kytos and Mininet.
 After all installations finish, the docker-compose file will call the kytos-init.sh script which takes care of finishing installing Kytos and all of the required 
 network applications in a quick and efficient way. This script is also responsible for executing all the tests within the projects repository via the commands::
 
-  $ python -m pytest --timeout=60 tests/
+  $ python3 -m pytest --timeout=60 tests/
 
 Which runs all available tests, or run only a specific test::
 
-  $ python -m pytest --timeout=60 \
+  $ python3 -m pytest --timeout=60 \
         tests/test_e2e_10_mef_eline.py::TestE2EMefEline::test_on_primary_path_fail_should_migrate_to_backup
 
 The above lines are entirely up to the user to modify, and will allow them to choose in which way they want to use the tests.

--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -11,7 +11,7 @@ sed -i 's/WARNING/INFO/g' /etc/kytos/logging.ini
 
 test -z "$TESTS" && TESTS=tests/ 
 
-python -m pytest $TESTS
+python3 -m pytest $TESTS
 
 # only run specific test
 # python -m pytest --timeout=60 tests/test_e2e_10_mef_eline.py::TestE2EMefEline::test_on_primary_path_fail_should_migrate_to_backup


### PR DESCRIPTION
Updated the `python` command to explicitly call `python3`, it turns out on Debian bullseye based on this PR that's under code review https://github.com/amlight/kytos-docker/pull/9, the base image also doesn't have `python` pointing to `python3`, so I figured explicitly would also keep it backwards compatible, and some distros traditionally use `python` as  Python 2.7 as well:

```
root@127bf29458f7:/#
root@127bf29458f7:/#
root@127bf29458f7:/# python
bash: python: command not found
root@127bf29458f7:/# python3
Python 3.9.2 (default, Feb 28 2021, 17:03:44)
[GCC 10.2.1 20210110] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>>
``` 