### PR TITLE
Update Kytos-init.sh to remove the log-e2e-date file

### DIFF
--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -15,7 +15,7 @@ sed -i 's/WARNING/INFO/g' /etc/kytos/logging.ini
 
 test -z "$TESTS" && TESTS=tests/
 
-python3 -m pytest $TESTS 2>&1 | tee log-e2e-$(date +%Y%m%d%H%M%S)
+python3 -m pytest $TESTS
 
 # only run specific test
 # python3 -m pytest --timeout=60 tests/test_e2e_10_mef_eline.py::TestE2EMefEline::test_on_primary_path_fail_should_migrate_to_backup


### PR DESCRIPTION
The extra logging `2>&1 | tee log-e2e-$(date +%Y%m%d%H%M%S)` was left by accident and it is not necessary as part of the testing script. In fact, the extra logging will mislead to successful execution of the script and leads to pipeline passing even when Pytest fails. 