### PR TITLE
Disable sdntrace and sdntrace-cp before running tests

### DIFF
--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -2,6 +2,12 @@
 
 set -xe
 
+# XXX: disable sdntrace and sdntrace_cp by default (along with their deps) while we are working on issue #110
+for napp in amlight/coloring amlight/sdntrace amlight/scheduler amlight/flow_stats amlight/sdntrace_cp; do
+   FILE=/var/lib/kytos/napps/$napp
+   test -h $FILE && unlink $FILE
+done
+
 # the settings below are intended to decrease the tests execution time (in fact, the time.sleep() calls
 # depend on the values below, otherwise many tests would fail)
 sed -i 's/STATS_INTERVAL = 60/STATS_INTERVAL = 3/g' /var/lib/kytos/napps/kytos/of_core/settings.py


### PR DESCRIPTION
This PR will disable Napps amlight/sdntrace and amlight/sdntrace-cp (along with their dependencies) to workaround issue #110. Those Napps used to be disabled in the docker image `amlight/kytos:latest` but they will be enabled by default as soon as amlight/kytos-docker#10 lands.