### PR TITLE
Add support to run test suites with MongoDB replicaset cluster

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,57 @@ services:
     volumes:
       - "./kytos-init.sh:/kytos-init.sh"
       - "./tests:/tests"
+      - "./scripts/wait_for_mongo.py:/wait_for_mongo.py"
     command:
       - /kytos-init.sh
+    environment:
+      MONGO_USERNAME: napp_user
+      MONGO_PASSWORD: napp_pw
+      MONGO_DBNAME: napps
+      MONGO_HOST_SEEDS: "mongo1t:27027,mongo2t:27028,mongo3t:27029"
+    depends_on:
+      - mongo-setup
+  mongo-setup:
+    container_name: mongo-test-rs-init
+    image: mongo:5.0
+    restart: on-failure
+    volumes:
+      - ./scripts:/scripts
+    entrypoint: ["/scripts/rs-init.sh"]
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root_user
+      MONGO_INITDB_ROOT_PASSWORD: root_pw
+      MONGO_USERNAME: napp_user
+      MONGO_PASSWORD: napp_pw
+      MONGO_DBNAME: napps
+    depends_on:
+      - mongo1t
+      - mongo2t
+      - mongo3t
+  mongo1t:
+    container_name: mongo1t
+    image: mongo:5.0
+    ports:
+      - 27027:27027
+    restart: always
+    entrypoint: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "rs0", "--port", "27027" ]
+    depends_on:
+      - mongo2t
+      - mongo3t
+  mongo2t:
+    container_name: mongo2t
+    image: mongo:5.0
+    ports:
+      - 27028:27028
+    restart: always
+    entrypoint: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "rs0", "--port", "27028" ]
+  mongo3t:
+    container_name: mongo3t
+    image: mongo:5.0
+    ports:
+      - 27029:27029
+    restart: always
+    entrypoint: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "rs0", "--port", "27029" ]
 #  mininet:
 #      image: italovalcy/mininet:latest
 #      privileged: true

--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -21,6 +21,7 @@ sed -i 's/WARNING/INFO/g' /etc/kytos/logging.ini
 
 test -z "$TESTS" && TESTS=tests/
 
+python3 /wait_for_mongo.py 2>/dev/null
 python3 -m pytest $TESTS
 
 # only run specific test

--- a/scripts/rs-init.sh
+++ b/scripts/rs-init.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+MONGO_NODES=(mongo1t:27027 mongo2t:27028 mongo3t:27029)
+
+echo "Waiting for mongo nodes serverStatus..."
+for mongo_node in "${MONGO_NODES[@]}"
+do
+  until curl http://${mongo_node}/serverStatus\?text\=1 2>&1 | grep uptime | head -1; do
+    printf '.'
+    sleep 5
+  done
+done
+echo "All mongo nodes are up"
+
+echo "Applying replicaSet rs0 config on ${MONGO_NODES[0]} at `date +"%T" `..."
+mongosh --host ${MONGO_NODES[0]} <<EOF
+var config = {
+    "_id": "rs0",
+    "protocolVersion": 1,
+    "version": 1,
+    "members": [
+        {
+            "_id": 1,
+            "host": "${MONGO_NODES[0]}",
+            "priority": 30
+        },
+        {
+            "_id": 2,
+            "host": "${MONGO_NODES[1]}",
+            "priority": 20
+        },
+        {
+            "_id": 3,
+            "host": "${MONGO_NODES[2]}",
+            "priority": 10
+        }
+    ]
+};
+rs.initiate(config, { force: true });
+rs.status();
+
+var curStatus = rs.status();
+while (curStatus.members[0].stateStr !== 'PRIMARY') {
+  print("Waiting for 1s while stateStr !== PRIMARY, current:", curStatus.members[0].stateStr);
+  sleep(1000);
+  curStatus = rs.status();
+}
+if (!curStatus) {
+  print("rs.status() failed, exiting, check the logs");
+  exit();
+}
+print("Primary node stateStr is PRIMARY.");
+
+admin = db.getSiblingDB("admin");
+admin.createUser(
+  {
+    user: process.env["MONGO_INITDB_ROOT_USERNAME"],
+    pwd: process.env["MONGO_INITDB_ROOT_PASSWORD"],
+    roles: [ { role: "root", db: "admin" } ]
+  }
+);
+napps = db.getSiblingDB("napps");
+napps.createUser(
+  {
+    user: process.env["MONGO_USERNAME"],
+    pwd: process.env["MONGO_PASSWORD"],
+    roles: [ { role: "dbAdmin", db: "napps" } ]
+  }
+);
+print("done all users have been created.");
+EOF

--- a/scripts/wait_for_mongo.py
+++ b/scripts/wait_for_mongo.py
@@ -1,0 +1,59 @@
+import os
+import sys
+from pymongo import MongoClient
+from pymongo.errors import OperationFailure, AutoReconnect
+
+
+def mongo_client(
+    host_seeds=os.environ.get("MONGO_HOST_SEEDS"),
+    username=os.environ.get("MONGO_USERNAME"),
+    password=os.environ.get("MONGO_PASSWORD"),
+    database=os.environ.get("MONGO_DBNAME"),
+    connect=False,
+    retrywrites=True,
+    retryreads=True,
+    readpreference="primaryPreferred",
+    maxpoolsize=int(os.environ.get("MONGO_MAX_POOLSIZE", 12)),
+    minpoolsize=int(os.environ.get("MONGO_MIN_POOLSIZE", 12)),
+    **kwargs,
+) -> MongoClient:
+    """mongo_client."""
+    return MongoClient(
+        host_seeds.split(","),
+        username=username,
+        password=password,
+        connect=False,
+        authsource=database,
+        retrywrites=retrywrites,
+        retryreads=retryreads,
+        readpreference=readpreference,
+        maxpoolsize=maxpoolsize,
+        minpoolsize=minpoolsize,
+        **kwargs,
+    )
+
+
+client = mongo_client()
+
+
+def mongo_hello_wait(retries=6, delay=10):
+    """Wait for MongoDB."""
+    try:
+        client.db.command("hello")
+        print("Sucessfully ran hello command on MongoDB. It's ready!")
+    except (OperationFailure, AutoReconnect) as exc:
+        retries -= 1
+        if retries > 0:
+            print("Retrying...")
+            return mongo_hello_wait(retries, delay)
+        print(f"Maximum retries reached when waiting for MongoDB. {str(exc)}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    print("Trying to run hello command on MongoDB...")
+    retries = 5
+    if len(sys.argv) > 1:
+        retries = int(sys.argv[1])
+
+    mongo_hello_wait(retries)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -6,6 +6,10 @@ from mock import patch
 import time
 import os
 
+from pymongo import MongoClient
+from pymongo.errors import ServerSelectionTimeoutError
+
+
 class AmlightTopo(Topo):
     """Amlight Topology."""
     def build(self):
@@ -134,8 +138,43 @@ topos = {
 }
 
 
+def mongo_client(
+    host_seeds=os.environ.get("MONGO_HOST_SEEDS"),
+    username=os.environ.get("MONGO_USERNAME"),
+    password=os.environ.get("MONGO_PASSWORD"),
+    database=os.environ.get("MONGO_DBNAME"),
+    connect=False,
+    retrywrites=True,
+    retryreads=True,
+    readpreference='primaryPreferred',
+    maxpoolsize=int(os.environ.get("MONGO_MAX_POOLSIZE", 20)),
+    minpoolsize=int(os.environ.get("MONGO_MIN_POOLSIZE", 10)),
+    **kwargs,
+) -> MongoClient:
+    """mongo_client."""
+    return MongoClient(
+        host_seeds.split(","),
+        username=username,
+        password=password,
+        connect=False,
+        authsource=database,
+        retrywrites=retrywrites,
+        retryreads=retryreads,
+        readpreference=readpreference,
+        maxpoolsize=maxpoolsize,
+        minpoolsize=minpoolsize,
+        **kwargs,
+    )
+
+
 class NetworkTest:
-    def __init__(self, controller_ip, topo_name='ring'):
+    def __init__(
+        self,
+        controller_ip,
+        topo_name="ring",
+        db_client=mongo_client,
+        db_client_options=None,
+    ):
         # Create an instance of our topology
         mininet.clean.cleanup()
 
@@ -148,10 +187,19 @@ class NetworkTest:
                 name, ip=controller_ip, port=6653),
             switch=OVSSwitch,
             autoSetMacs=True)
+        db_client_kwargs = db_client_options or {}
+        db_name = db_client_kwargs.get("database") or os.environ.get("MONGO_DBNAME")
+        self.db_client = db_client(**db_client_kwargs)
+        self.db_name = db_name
+        self.db = self.db_client[self.db_name]
 
     def start(self):
         self.net.start()
         self.start_controller(clean_config=True)
+
+    def drop_database(self):
+        """Drop database."""
+        self.db_client.drop_database(self.db_name)
 
     def start_controller(self, clean_config=False, enable_all=False, del_flows=False, port=None):
         # Restart kytos and check if the napp is still disabled
@@ -172,6 +220,10 @@ class NetworkTest:
             # TODO: config is defined at NAPPS_DIR/kytos/storehouse/settings.py 
             # and NAPPS_DIR is defined at /etc/kytos/kytos.conf
             os.system('rm -rf /var/tmp/kytos/storehouse')
+            try:
+                self.drop_database()
+            except ServerSelectionTimeoutError as exc:
+                print(f"FAIL to drop database. {str(exc)}")
 
         if clean_config or del_flows:
             # Remove any installed flow

--- a/tests/test_e2e_05_topology.py
+++ b/tests/test_e2e_05_topology.py
@@ -1,5 +1,6 @@
 import json
 import requests
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from tests.helpers import NetworkTest
 import time
 
@@ -193,6 +194,43 @@ class TestE2ETopology:
         data = response.json()
         keys = data['metadata'].keys()
         assert key not in keys
+
+    def test_045_insert_switch_metadata_concurrently(self):
+        """
+        Test /api/kytos/topology/v3/switches/{dpid}/metadata/{key} on POST
+        supported by:
+            /api/kytos/topology/v3/switches/{dpid}/metadata on GET
+        """
+        switch_id = "00:00:00:00:00:00:00:01"
+
+        n_keys = 100
+
+        def insert_metadata(metadata):
+            payload = metadata
+            api_url = f"{KYTOS_API}/topology/v3/switches/{switch_id}/metadata"
+            return requests.post(
+                api_url,
+                data=json.dumps(payload),
+                headers={"Content-type": "application/json"},
+            )
+
+        metadatas = [{str(k): k for k in range(n_keys)}]
+        with ThreadPoolExecutor(max_workers=n_keys) as executor:
+            futures = [
+                executor.submit(insert_metadata, metadata) for metadata in metadatas
+            ]
+            for future in as_completed(futures):
+                response = future.result()
+                assert response.status_code == 201, response.text
+
+        # Verify that the metadata is inserted
+        api_url = KYTOS_API + '/topology/v3/switches/%s/metadata' % switch_id
+        response = requests.get(api_url)
+        data = response.json()
+        keys = list(data['metadata'].keys())
+        expected_keys = [str(k) for k in range(n_keys)]
+        diff = set(expected_keys) - set(keys)
+        assert len(diff) == 0, f"Keys set difference: {diff}"
 
     def test_050_enabling_interface_persistent(self):
         """

--- a/tests/test_e2e_05_topology.py
+++ b/tests/test_e2e_05_topology.py
@@ -615,6 +615,8 @@ class TestE2ETopology:
         api_url = KYTOS_API + '/topology/v3/interfaces'
         response = requests.get(api_url)
         data = response.json()
+
+        assert response.status_code == 200, response.text
         for interface in data['interfaces']:
             assert data['interfaces'][interface]['enabled'] is False
 


### PR DESCRIPTION
Fixes #128 

- Added support to run test suites with MongoDB replicaset cluster
- Augmented docker-compose to spin up a MongoDB replicaset cluster
- Added scripts to bootstrap the cluster
- Added a script to wait for mongo, this is needed to ensure that the cluster is ready before starting the tests. 
- Augmented `NetworkTest` to also clean up and teardown the MongoDB database instance 
- Added a new test case `test_045_insert_switch_metadata_concurrently` since I encountered some concurrency issues early on when developing (it's fixed now), so I figured it'd be great to have to make sure it doesn't cause regressions. 

Locally all topology tests related are passing, however on gitlab there's it's going to be more adjustments there, since it's not using docker compose up there yet, I'll sync with @italovalcy to see how we'll go about this. 

```
+ TESTS=tests/
+ python3 /wait_for_mongo.py
Trying to run hello command on MongoDB...
Successfully ran hello command on MongoDB. It's ready!
+ python3 -m pytest --timeout=180 tests -k 05_topology
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /tests
plugins: timeout-2.0.2
timeout: 180.0s
timeout method: signal
timeout func_only: False
collected 190 items / 172 deselected / 18 selected

tests/test_e2e_05_topology.py ..................                         [100%]

=============================== warnings summary ===============================
test_e2e_05_topology.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <

test_e2e_05_topology.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )

-- Docs: https://docs.pytest.org/en/stable/warnings.html
------------------------------- start/stop times -------------------------------
========= 18 passed, 172 deselected, 34 warnings in 866.35s (0:14:26) ==========
```