### PR TITLE
Adapted startup tests not to expect storehouse on `/core/napps_enabled/`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,8 +37,9 @@ Requirements
 * Python
 * Mininet
 * Docker
+* docker-compose
+* MongoDB (run via docker-compose)
 * Kytos SDN Controller
-* kytos/storehouse
 * kytos/of_core 
 * kytos/flow_manager 
 * kytos/topology 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -218,15 +218,11 @@ class NetworkTest:
             os.system('pkill -9 kytosd')
             os.system('rm -f /var/run/kytos/kytosd.pid')
 
-        if clean_config:
-            # TODO: config is defined at NAPPS_DIR/kytos/storehouse/settings.py 
-            # and NAPPS_DIR is defined at /etc/kytos/kytos.conf
-            os.system('rm -rf /var/tmp/kytos/storehouse')
-            if database:
-                try:
-                    self.drop_database()
-                except ServerSelectionTimeoutError as exc:
-                    print(f"FAIL to drop database. {str(exc)}")
+        if clean_config and database:
+            try:
+                self.drop_database()
+            except ServerSelectionTimeoutError as exc:
+                print(f"FAIL to drop database. {str(exc)}")
 
         if clean_config or del_flows:
             # Remove any installed flow

--- a/tests/test_e2e_01_kytos_startup.py
+++ b/tests/test_e2e_01_kytos_startup.py
@@ -55,7 +55,6 @@ class TestE2EKytosServer:
                 ("kytos", "pathfinder"),
                 ("kytos", "mef_eline"),
                 ("kytos", "maintenance"),
-                ("kytos", "storehouse"),
                 ("kytos", "flow_manager"),
                 ("kytos", "of_core"),
                 ("kytos", "topology"),


### PR DESCRIPTION
- Adapted startup tests not to expect storehouse on `/core/napps_enabled/`