### PR TITLE
[Feature] Added e2e test for LLDP loop_detection disable action

### DIFF
--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -16,7 +16,7 @@ sed -i 's/DEPLOY_EVCS_INTERVAL = 60/DEPLOY_EVCS_INTERVAL = 5/g' /var/lib/kytos/n
 sed -i 's/BOX_RESTORE_TIMER = 0.1/BOX_RESTORE_TIMER = 0.5/' /var/lib/kytos/napps/kytos/flow_manager/settings.py
 #sed -n '10p' /var/lib/kytos/napps/kytos/of_lldp/settings.py
 sed -i 's/LLDP_LOOP_ACTIONS = \["log"\]/BLLDP_LOOP_ACTIONS = \["disable,log"\]/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
-#sed -n '10p' /var/lib/kytos/napps/kytos/of_lldp/settings.py
+sed -n '10p' /var/lib/kytos/napps/kytos/of_lldp/settings.py
 # increase logging to facilitate troubleshooting
 kytosd --help >/dev/null 2>&1  ## create configs at /etc/kytos from templates
 sed -i 's/WARNING/INFO/g' /etc/kytos/logging.ini

--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -14,6 +14,8 @@ sed -i 's/STATS_INTERVAL = 60/STATS_INTERVAL = 3/g' /var/lib/kytos/napps/kytos/o
 sed -i 's/LINK_UP_TIMER = 10/LINK_UP_TIMER = 1/g' /var/lib/kytos/napps/kytos/topology/settings.py
 sed -i 's/DEPLOY_EVCS_INTERVAL = 60/DEPLOY_EVCS_INTERVAL = 5/g' /var/lib/kytos/napps/kytos/mef_eline/settings.py
 sed -i 's/BOX_RESTORE_TIMER = 0.1/BOX_RESTORE_TIMER = 0.5/' /var/lib/kytos/napps/kytos/flow_manager/settings.py
+sed -i 's/LLDP_LOOP_ACTIONS = ["log"]/BLLDP_LOOP_ACTIONS = ["disable"]/g' /var/lib/kytos/napps/kytos/of_lldp/settings.py
+echo &(nano /var/lib/kytos/napps/kytos/of_lldp/settings.py)
 
 # increase logging to facilitate troubleshooting
 kytosd --help >/dev/null 2>&1  ## create configs at /etc/kytos from templates
@@ -22,7 +24,10 @@ sed -i 's/WARNING/INFO/g' /etc/kytos/logging.ini
 test -z "$TESTS" && TESTS=tests/
 
 python3 scripts/wait_for_mongo.py 2>/dev/null
+python3 -m pytest --capture=tee-sys tests/test_e2e_31_of_lldp_loop_detection.py::TestE2EOfLLDPLoopDetection::test_001_loop_detection_disable_action
 python3 -m pytest $TESTS
+
+#tail -f
 
 # only run specific test
 # python3 -m pytest --timeout=60 tests/test_e2e_10_mef_eline.py::TestE2EMefEline::test_on_primary_path_fail_should_migrate_to_backup

--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -14,8 +14,12 @@ sed -i 's/STATS_INTERVAL = 60/STATS_INTERVAL = 3/g' /var/lib/kytos/napps/kytos/o
 sed -i 's/LINK_UP_TIMER = 10/LINK_UP_TIMER = 1/g' /var/lib/kytos/napps/kytos/topology/settings.py
 sed -i 's/DEPLOY_EVCS_INTERVAL = 60/DEPLOY_EVCS_INTERVAL = 5/g' /var/lib/kytos/napps/kytos/mef_eline/settings.py
 sed -i 's/BOX_RESTORE_TIMER = 0.1/BOX_RESTORE_TIMER = 0.5/' /var/lib/kytos/napps/kytos/flow_manager/settings.py
-sed -i 's/LLDP_LOOP_ACTIONS = \["log"\]/LLDP_LOOP_ACTIONS = \["disable,log"\]/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
+sed -i 's/LLDP_LOOP_ACTIONS = \["log"\]/LLDP_LOOP_ACTIONS = \["disable","log"\]/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
+sed -i 's/LLDP_IGNORED_LOOPS = {"00:00:00:00:00:00:00:01": \[\[4, 5\]\]}/LLDP_IGNORED_LOOPS = {}/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
 sed -i 's/LLDP_IGNORED_LOOPS = {}/LLDP_IGNORED_LOOPS = {"00:00:00:00:00:00:00:01": \[\[4, 5\]\]}/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
+#sed -i 's/LLDP_IGNORED_LOOPS = {"00:00:00:00:00:00:00:01": \[\[4, 5\]\]}/LLDP_IGNORED_LOOPS = {}/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
+sed -n '10p' /var/lib/kytos/napps/kytos/of_lldp/settings.py
+sed -n '11p' /var/lib/kytos/napps/kytos/of_lldp/settings.py
 
 # increase logging to facilitate troubleshooting
 kytosd --help >/dev/null 2>&1  ## create configs at /etc/kytos from templates
@@ -24,9 +28,11 @@ sed -i 's/WARNING/INFO/g' /etc/kytos/logging.ini
 test -z "$TESTS" && TESTS=tests/
 
 python3 scripts/wait_for_mongo.py 2>/dev/null
-python3 -m pytest --capture=tee-sys tests/test_e2e_31_of_lldp_loop_detection.py
+#python3 -m pytest --capture=tee-sys tests/test_e2e_31_of_lldp_loop_detection.py::TestE2EOfLLDPLoopDetection::test_001_loop_detection_disable_action
+#python3 -m pytest --capture=tee-sys tests/test_e2e_31_of_lldp_loop_detection.py::TestE2EOfLLDPLoopDetection::test_010_lldp_ignored_loops
+python3 -m pytest --capture=tee-sys tests/test_e2e_31_of_lldp_loop_detection.py::TestE2EOfLLDPLoopDetection::test_020_reconfigure_ignored_loops
 
-python3 -m pytest $TESTS
+#python3 -m pytest $TESTS
 
 #tail -f
 

--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -14,9 +14,9 @@ sed -i 's/STATS_INTERVAL = 60/STATS_INTERVAL = 3/g' /var/lib/kytos/napps/kytos/o
 sed -i 's/LINK_UP_TIMER = 10/LINK_UP_TIMER = 1/g' /var/lib/kytos/napps/kytos/topology/settings.py
 sed -i 's/DEPLOY_EVCS_INTERVAL = 60/DEPLOY_EVCS_INTERVAL = 5/g' /var/lib/kytos/napps/kytos/mef_eline/settings.py
 sed -i 's/BOX_RESTORE_TIMER = 0.1/BOX_RESTORE_TIMER = 0.5/' /var/lib/kytos/napps/kytos/flow_manager/settings.py
-sed -i 's/LLDP_LOOP_ACTIONS = ["log"]/BLLDP_LOOP_ACTIONS = ["disable"]/g' /var/lib/kytos/napps/kytos/of_lldp/settings.py
-echo &(nano /var/lib/kytos/napps/kytos/of_lldp/settings.py)
-
+#sed -n '10p' /var/lib/kytos/napps/kytos/of_lldp/settings.py
+sed -i 's/LLDP_LOOP_ACTIONS = \["log"\]/BLLDP_LOOP_ACTIONS = \["disable,log"\]/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
+#sed -n '10p' /var/lib/kytos/napps/kytos/of_lldp/settings.py
 # increase logging to facilitate troubleshooting
 kytosd --help >/dev/null 2>&1  ## create configs at /etc/kytos from templates
 sed -i 's/WARNING/INFO/g' /etc/kytos/logging.ini

--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -14,9 +14,9 @@ sed -i 's/STATS_INTERVAL = 60/STATS_INTERVAL = 3/g' /var/lib/kytos/napps/kytos/o
 sed -i 's/LINK_UP_TIMER = 10/LINK_UP_TIMER = 1/g' /var/lib/kytos/napps/kytos/topology/settings.py
 sed -i 's/DEPLOY_EVCS_INTERVAL = 60/DEPLOY_EVCS_INTERVAL = 5/g' /var/lib/kytos/napps/kytos/mef_eline/settings.py
 sed -i 's/BOX_RESTORE_TIMER = 0.1/BOX_RESTORE_TIMER = 0.5/' /var/lib/kytos/napps/kytos/flow_manager/settings.py
-#sed -n '10p' /var/lib/kytos/napps/kytos/of_lldp/settings.py
 sed -i 's/LLDP_LOOP_ACTIONS = \["log"\]/BLLDP_LOOP_ACTIONS = \["disable,log"\]/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
-sed -n '10p' /var/lib/kytos/napps/kytos/of_lldp/settings.py
+sed -i 's/LLDP_IGNORED_LOOPS = {}/LLDP_IGNORED_LOOPS = {"00:00:00:00:00:00:00:01": \[\[4, 5\]\]}/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
+
 # increase logging to facilitate troubleshooting
 kytosd --help >/dev/null 2>&1  ## create configs at /etc/kytos from templates
 sed -i 's/WARNING/INFO/g' /etc/kytos/logging.ini
@@ -24,7 +24,9 @@ sed -i 's/WARNING/INFO/g' /etc/kytos/logging.ini
 test -z "$TESTS" && TESTS=tests/
 
 python3 scripts/wait_for_mongo.py 2>/dev/null
-python3 -m pytest --capture=tee-sys tests/test_e2e_31_of_lldp_loop_detection.py::TestE2EOfLLDPLoopDetection::test_001_loop_detection_disable_action
+#python3 -m pytest tests/test_e2e_31_of_lldp_loop_detection.py
+python3 -m pytest --capture=tee-sys tests/test_e2e_31_of_lldp_loop_detection.py
+
 python3 -m pytest $TESTS
 
 #tail -f

--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -24,7 +24,8 @@ sed -i 's/WARNING/INFO/g' /etc/kytos/logging.ini
 test -z "$TESTS" && TESTS=tests/
 
 python3 scripts/wait_for_mongo.py 2>/dev/null
-python3 -m pytest $TESTS
+python3 -m pytest tests/test_e2e_15_maintenance.py::TestE2EMaintenance.test_085_end_running_mw_on_switch
+#python3 -m pytest $TESTS
 
 #tail -f
 

--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -24,8 +24,7 @@ sed -i 's/WARNING/INFO/g' /etc/kytos/logging.ini
 test -z "$TESTS" && TESTS=tests/
 
 python3 scripts/wait_for_mongo.py 2>/dev/null
-python3 -m pytest tests/test_e2e_32_of_lldp.py
-#python3 -m pytest $TESTS
+python3 -m pytest $TESTS
 
 #tail -f
 

--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -30,8 +30,8 @@ test -z "$TESTS" && TESTS=tests/
 python3 scripts/wait_for_mongo.py 2>/dev/null
 #python3 -m pytest --capture=tee-sys tests/test_e2e_31_of_lldp_loop_detection.py::TestE2EOfLLDPLoopDetection::test_001_loop_detection_disable_action
 #python3 -m pytest --capture=tee-sys tests/test_e2e_31_of_lldp_loop_detection.py::TestE2EOfLLDPLoopDetection::test_010_lldp_ignored_loops
-python3 -m pytest --capture=tee-sys tests/test_e2e_31_of_lldp_loop_detection.py::TestE2EOfLLDPLoopDetection::test_020_reconfigure_ignored_loops
-
+#python3 -m pytest --capture=tee-sys tests/test_e2e_31_of_lldp_loop_detection.py::TestE2EOfLLDPLoopDetection::test_020_reconfigure_ignored_loops
+python3 -m pytest --capture=tee-sys tests/test_e2e_31_of_lldp_loop_detection.py
 #python3 -m pytest $TESTS
 
 #tail -f

--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -14,7 +14,7 @@ sed -i 's/STATS_INTERVAL = 60/STATS_INTERVAL = 3/g' /var/lib/kytos/napps/kytos/o
 sed -i 's/LINK_UP_TIMER = 10/LINK_UP_TIMER = 1/g' /var/lib/kytos/napps/kytos/topology/settings.py
 sed -i 's/DEPLOY_EVCS_INTERVAL = 60/DEPLOY_EVCS_INTERVAL = 5/g' /var/lib/kytos/napps/kytos/mef_eline/settings.py
 sed -i 's/BOX_RESTORE_TIMER = 0.1/BOX_RESTORE_TIMER = 0.5/' /var/lib/kytos/napps/kytos/flow_manager/settings.py
-sed -i 's/LLDP_LOOP_ACTIONS = \["log"\]/BLLDP_LOOP_ACTIONS = \["disable,log"\]/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
+sed -i 's/LLDP_LOOP_ACTIONS = \["log"\]/LLDP_LOOP_ACTIONS = \["disable,log"\]/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
 sed -i 's/LLDP_IGNORED_LOOPS = {}/LLDP_IGNORED_LOOPS = {"00:00:00:00:00:00:00:01": \[\[4, 5\]\]}/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
 
 # increase logging to facilitate troubleshooting
@@ -24,7 +24,6 @@ sed -i 's/WARNING/INFO/g' /etc/kytos/logging.ini
 test -z "$TESTS" && TESTS=tests/
 
 python3 scripts/wait_for_mongo.py 2>/dev/null
-#python3 -m pytest tests/test_e2e_31_of_lldp_loop_detection.py
 python3 -m pytest --capture=tee-sys tests/test_e2e_31_of_lldp_loop_detection.py
 
 python3 -m pytest $TESTS

--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -15,11 +15,7 @@ sed -i 's/LINK_UP_TIMER = 10/LINK_UP_TIMER = 1/g' /var/lib/kytos/napps/kytos/top
 sed -i 's/DEPLOY_EVCS_INTERVAL = 60/DEPLOY_EVCS_INTERVAL = 5/g' /var/lib/kytos/napps/kytos/mef_eline/settings.py
 sed -i 's/BOX_RESTORE_TIMER = 0.1/BOX_RESTORE_TIMER = 0.5/' /var/lib/kytos/napps/kytos/flow_manager/settings.py
 sed -i 's/LLDP_LOOP_ACTIONS = \["log"\]/LLDP_LOOP_ACTIONS = \["disable","log"\]/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
-sed -i 's/LLDP_IGNORED_LOOPS = {"00:00:00:00:00:00:00:01": \[\[4, 5\]\]}/LLDP_IGNORED_LOOPS = {}/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
 sed -i 's/LLDP_IGNORED_LOOPS = {}/LLDP_IGNORED_LOOPS = {"00:00:00:00:00:00:00:01": \[\[4, 5\]\]}/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
-#sed -i 's/LLDP_IGNORED_LOOPS = {"00:00:00:00:00:00:00:01": \[\[4, 5\]\]}/LLDP_IGNORED_LOOPS = {}/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
-sed -n '10p' /var/lib/kytos/napps/kytos/of_lldp/settings.py
-sed -n '11p' /var/lib/kytos/napps/kytos/of_lldp/settings.py
 
 # increase logging to facilitate troubleshooting
 kytosd --help >/dev/null 2>&1  ## create configs at /etc/kytos from templates
@@ -28,10 +24,7 @@ sed -i 's/WARNING/INFO/g' /etc/kytos/logging.ini
 test -z "$TESTS" && TESTS=tests/
 
 python3 scripts/wait_for_mongo.py 2>/dev/null
-#python3 -m pytest --capture=tee-sys tests/test_e2e_31_of_lldp_loop_detection.py::TestE2EOfLLDPLoopDetection::test_001_loop_detection_disable_action
-#python3 -m pytest --capture=tee-sys tests/test_e2e_31_of_lldp_loop_detection.py::TestE2EOfLLDPLoopDetection::test_010_lldp_ignored_loops
-#python3 -m pytest --capture=tee-sys tests/test_e2e_31_of_lldp_loop_detection.py::TestE2EOfLLDPLoopDetection::test_020_reconfigure_ignored_loops
-python3 -m pytest --capture=tee-sys tests/test_e2e_31_of_lldp_loop_detection.py
+python3 -m pytest tests/test_e2e_32_of_lldp.py
 #python3 -m pytest $TESTS
 
 #tail -f

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -197,7 +197,7 @@ class NetworkTest:
         # OVS and controlled by a remote controller
         patch('mininet.util.fixLimits', side_effect=None)
         self.net = Mininet(
-            topo=topos.get(topo_name, topos['looped'])(),
+            topo=topos.get(topo_name, topos[topo_name])(),
             controller=lambda name: RemoteController(
                 name, ip=controller_ip, port=6653),
             switch=OVSSwitch,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -140,6 +140,7 @@ class Looped(Topo):
         s2 = self.addSwitch("s2")
 
         self.addLink(s1, s1, port1=1, port2=2)
+        self.addLink(s1, s1, port1=4, port2=5)
         self.addLink(s1, s2, port1=3, port2=1)
 
 # You can run any of the topologies above by doing:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -129,6 +129,18 @@ class Ring4Topo(Topo):
         self.addLink(s3, s4)
         self.addLink(s4, s1)
 
+class Looped(Topo):
+    """ Network with two switches
+    and a loop in one switch."""
+
+    def build(self):
+        "Create custom topo."
+
+        s1 = self.addSwitch("s1")
+        s2 = self.addSwitch("s2")
+
+        self.addLink(s1, s1, port1=1, port2=2)
+        self.addLink(s1, s2, port1=3, port2=1)
 
 # You can run any of the topologies above by doing:
 # mn --custom tests/helpers.py --topo ring --controller=remote,ip=127.0.0.1
@@ -136,6 +148,7 @@ topos = {
     'ring': (lambda: RingTopo()),
     'ring4': (lambda: Ring4Topo()),
     'amlight': (lambda: AmlightTopo()),
+    'looped': (lambda: Looped()),
 }
 
 
@@ -183,7 +196,7 @@ class NetworkTest:
         # OVS and controlled by a remote controller
         patch('mininet.util.fixLimits', side_effect=None)
         self.net = Mininet(
-            topo=topos.get(topo_name, (lambda: RingTopo()))(),
+            topo=topos.get(topo_name, topos['looped'])(),
             controller=lambda name: RemoteController(
                 name, ip=controller_ip, port=6653),
             switch=OVSSwitch,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -197,7 +197,7 @@ class NetworkTest:
         # OVS and controlled by a remote controller
         patch('mininet.util.fixLimits', side_effect=None)
         self.net = Mininet(
-            topo=topos.get(topo_name, topos[topo_name])(),
+            topo=topos.get(topo_name, (lambda: RingTopo()))(),
             controller=lambda name: RemoteController(
                 name, ip=controller_ip, port=6653),
             switch=OVSSwitch,

--- a/tests/test_e2e_31_of_lldp_loop_detection.py
+++ b/tests/test_e2e_31_of_lldp_loop_detection.py
@@ -1,0 +1,130 @@
+import requests
+from tests.helpers import NetworkTest
+import time
+
+CONTROLLER = '127.0.0.1'
+KYTOS_API = 'http://%s:8181/api/kytos' % CONTROLLER
+
+
+class TestE2EOfLLDPLoopDetection:
+    net = None
+
+    @classmethod
+    def setup_class(cls):
+        cls.net = NetworkTest(CONTROLLER, topo_name='looped')
+        cls.net.start()
+        cls.net.restart_kytos_clean()
+        cls.net.wait_switches_connect()
+        time.sleep(10)
+
+    @classmethod
+    def teardown_class(cls):
+        cls.net.stop()
+
+    def restart(self, _clean_config=False, _enable_all=False):
+
+        # Start the controller setting an environment in which the setting is
+        # preserved and avoid the default enabling of all elements
+        self.net.start_controller(clean_config=_clean_config, enable_all=_enable_all)
+        self.net.wait_switches_connect()
+
+        # Wait a few seconds 
+        time.sleep(10)
+
+    def test_001_loop_detection_disable_action(self):
+        """ This will test that given a looped topology, assuming that there is a loop
+        it's going to shutdown the interface. """
+
+        polling_time = 5
+
+        interface_id = "00:00:00:00:00:00:00:01:1"
+
+        # GET topology with the interface ensuring that it's enabled
+        api_url = KYTOS_API + '/of_lldp/v1/interfaces/'
+        response = requests.get(api_url)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert 'interfaces' in data
+        assert data[interface_id]['enabled'] == True
+
+        # WAIT for some time, until the feature kicks
+        time.sleep(polling_time)
+
+        # GET topology with the interface ensuring that it's disabled
+        response = requests.get(api_url)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert 'interfaces' in data
+        assert data[interface_id]['enabled'] == False
+
+
+    def test_010_lldp_ignored_loops(self):
+        """ Test that the ports 4 and 5 are ignored. """
+
+        polling_time = 5
+
+        interface_id4 = "00:00:00:00:00:00:00:01:4"
+        interface_id5 = "00:00:00:00:00:00:00:01:5"
+
+        # GET topology with the interfaces ensuring that they are enabled
+        api_url = KYTOS_API + '/of_lldp/v1/interfaces/'
+        response = requests.get(api_url)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert 'interfaces' in data
+        assert data[interface_id4]['enabled'] == True
+        assert data[interface_id5]['enabled'] == True
+
+        # WAIT for some time, until the feature kicks
+        time.sleep(polling_time)
+
+        # GET topology with the interface ensuring that they are enabled
+        response = requests.get(api_url)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert 'interfaces' in data
+        assert data[interface_id4]['enabled'] == True
+        assert data[interface_id5]['enabled'] == True
+
+
+    def test_020_reconfigure_ignored_loops(self):
+        """ Test that when we reconfigure the ignored loop with 
+        POST /api/kytos/topology/v3/switches/{{dpid}}/metadata 
+        the loops aren't ignored anymore.. """
+
+        polling_time = 5
+
+        interface_id4 = "00:00:00:00:00:00:00:01:4"
+        interface_id5 = "00:00:00:00:00:00:00:01:5"
+
+        # GET topology with the interfaces ensuring that they are enabled
+        api_url = KYTOS_API + '/of_lldp/v1/interfaces/'
+        response = requests.get(api_url)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert 'interfaces' in data
+        assert data[interface_id4]['enabled'] == True
+        assert data[interface_id5]['enabled'] == True
+
+        # Reconfigure the ignored loop
+        switch_id = "00:00:00:00:00:00:00:01"
+        api_url = KYTOS_API + '/topology/v3/switches/%s/metadata' % switch_id
+        response = requests.post(api_url, json={"ignored_loops": []})
+        assert response.status_code == 200, response.text
+
+        self.restart()
+
+        # WAIT for some time, until the feature kicks
+        time.sleep(polling_time)
+
+        # GET topology with the interface ensuring that they are enabled
+        assert data[interface_id4]['enabled'] == False
+        assert data[interface_id5]['enabled'] == False
+
+
+
+
+
+
+
+        

--- a/tests/test_e2e_31_of_lldp_loop_detection.py
+++ b/tests/test_e2e_31_of_lldp_loop_detection.py
@@ -37,25 +37,28 @@ class TestE2EOfLLDPLoopDetection:
 
         polling_time = 5
 
+        switch = "00:00:00:00:00:00:00:01"
         interface_id = "00:00:00:00:00:00:00:01:1"
 
         # GET topology with the interface ensuring that it's enabled
-        api_url = KYTOS_API + '/of_lldp/v1/interfaces/'
+        api_url = KYTOS_API + '/topology/v3/switches' 
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
-        assert 'interfaces' in data
-        assert data[interface_id]['enabled'] == True
+        assert 'switches' in data
+        assert data['switches'][switch]['interfaces'][interface_id]['enabled'] == True
 
         # WAIT for some time, until the feature kicks
         time.sleep(polling_time)
 
         # GET topology with the interface ensuring that it's disabled
+        api_url = KYTOS_API + '/topology/v3/switches' 
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
-        assert 'interfaces' in data
-        assert data[interface_id]['enabled'] == False
+        assert 'switches' in data
+        print(data['switches'][switch]['interfaces'][interface_id])
+        assert data['switches'][switch]['interfaces'][interface_id]['enabled'] == False
 
 
     def test_010_lldp_ignored_loops(self):
@@ -63,28 +66,30 @@ class TestE2EOfLLDPLoopDetection:
 
         polling_time = 5
 
+        switch = "00:00:00:00:00:00:00:01"
         interface_id4 = "00:00:00:00:00:00:00:01:4"
         interface_id5 = "00:00:00:00:00:00:00:01:5"
 
         # GET topology with the interfaces ensuring that they are enabled
-        api_url = KYTOS_API + '/of_lldp/v1/interfaces/'
+        api_url = KYTOS_API + '/topology/v3/switches' 
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
-        assert 'interfaces' in data
-        assert data[interface_id4]['enabled'] == True
-        assert data[interface_id5]['enabled'] == True
+        assert 'switches' in data
+        assert data['switches'][switch]['interfaces'][interface_id4]['enabled'] == True
+        assert data['switches'][switch]['interfaces'][interface_id5]['enabled'] == True
 
         # WAIT for some time, until the feature kicks
         time.sleep(polling_time)
 
         # GET topology with the interface ensuring that they are enabled
+        api_url = KYTOS_API + '/topology/v3/switches' 
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
-        assert 'interfaces' in data
-        assert data[interface_id4]['enabled'] == True
-        assert data[interface_id5]['enabled'] == True
+        assert 'switches' in data
+        assert data['switches'][switch]['interfaces'][interface_id4]['enabled'] == True
+        assert data['switches'][switch]['interfaces'][interface_id5]['enabled'] == True
 
 
     def test_020_reconfigure_ignored_loops(self):
@@ -92,23 +97,24 @@ class TestE2EOfLLDPLoopDetection:
         POST /api/kytos/topology/v3/switches/{{dpid}}/metadata 
         the loops aren't ignored anymore.. """
 
+ 
         polling_time = 5
 
+        switch = "00:00:00:00:00:00:00:01"
         interface_id4 = "00:00:00:00:00:00:00:01:4"
         interface_id5 = "00:00:00:00:00:00:00:01:5"
 
         # GET topology with the interfaces ensuring that they are enabled
-        api_url = KYTOS_API + '/of_lldp/v1/interfaces/'
+        api_url = KYTOS_API + '/topology/v3/switches' 
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
-        assert 'interfaces' in data
-        assert data[interface_id4]['enabled'] == True
-        assert data[interface_id5]['enabled'] == True
+        assert 'switches' in data
+        assert data['switches'][switch]['interfaces'][interface_id4]['enabled'] == True
+        assert data['switches'][switch]['interfaces'][interface_id5]['enabled'] == True
 
         # Reconfigure the ignored loop
-        switch_id = "00:00:00:00:00:00:00:01"
-        api_url = KYTOS_API + '/topology/v3/switches/%s/metadata' % switch_id
+        api_url = KYTOS_API + '/topology/v3/switches/%s/metadata' % switch
         response = requests.post(api_url, json={"ignored_loops": []})
         assert response.status_code == 200, response.text
 
@@ -118,9 +124,13 @@ class TestE2EOfLLDPLoopDetection:
         time.sleep(polling_time)
 
         # GET topology with the interface ensuring that they are enabled
-        assert data[interface_id4]['enabled'] == False
-        assert data[interface_id5]['enabled'] == False
-
+        api_url = KYTOS_API + '/topology/v3/switches' 
+        response = requests.get(api_url)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert 'switches' in data
+        assert data['switches'][switch]['interfaces'][interface_id4]['enabled'] == True
+        assert data['switches'][switch]['interfaces'][interface_id5]['enabled'] == True
 
 
 

--- a/tests/test_e2e_31_of_lldp_loop_detection.py
+++ b/tests/test_e2e_31_of_lldp_loop_detection.py
@@ -113,14 +113,6 @@ class TestE2EOfLLDPLoopDetection:
         # WAIT for some time, until the feature kicks
         time.sleep(polling_time)
 
-        # check
-        # api_url = KYTOS_API + '/topology/v3/switches' 
-        # response = requests.get(api_url)
-        # assert response.status_code == 200, response.text
-        # data = response.json()
-        # print(data['switches'][switch]['interfaces'][interface_id4]['metadata']) #looped in 
-        # print(data['switches'][switch]['metadata']) #ignored_loops: [] 
-        
         # Reconfigure the ignored loops
         api_url = KYTOS_API + '/topology/v3/switches/%s/metadata' % switch
         response = requests.post(api_url, json={"ignored_loops": []})

--- a/tests/test_e2e_31_of_lldp_loop_detection.py
+++ b/tests/test_e2e_31_of_lldp_loop_detection.py
@@ -35,30 +35,28 @@ class TestE2EOfLLDPLoopDetection:
         """ This will test that given a looped topology, assuming that there is a loop
         it's going to shutdown the interface. """
 
-        polling_time = 5
+        polling_time = 60
 
         switch = "00:00:00:00:00:00:00:01"
         interface_id = "00:00:00:00:00:00:00:01:1"
 
         # GET topology with the interface ensuring that it's enabled
-        api_url = KYTOS_API + '/topology/v3/switches' 
+        api_url = KYTOS_API + '/topology/v3/interfaces' 
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
-        assert 'switches' in data
-        assert data['switches'][switch]['interfaces'][interface_id]['enabled'] == True
+        assert data['interfaces'][interface_id]['enabled'] == True
 
         # WAIT for some time, until the feature kicks
         time.sleep(polling_time)
 
         # GET topology with the interface ensuring that it's disabled
-        api_url = KYTOS_API + '/topology/v3/switches' 
+        api_url = KYTOS_API + '/topology/v3/interfaces' 
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
-        assert 'switches' in data
-        print(data['switches'][switch]['interfaces'][interface_id])
-        assert data['switches'][switch]['interfaces'][interface_id]['enabled'] == False
+        print(data)
+        assert data['interfaces'][interface_id]['enabled'] == False
 
 
     def test_010_lldp_ignored_loops(self):
@@ -66,30 +64,27 @@ class TestE2EOfLLDPLoopDetection:
 
         polling_time = 5
 
-        switch = "00:00:00:00:00:00:00:01"
         interface_id4 = "00:00:00:00:00:00:00:01:4"
         interface_id5 = "00:00:00:00:00:00:00:01:5"
 
         # GET topology with the interfaces ensuring that they are enabled
-        api_url = KYTOS_API + '/topology/v3/switches' 
+        api_url = KYTOS_API + '/topology/v3/interfaces' 
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
-        assert 'switches' in data
-        assert data['switches'][switch]['interfaces'][interface_id4]['enabled'] == True
-        assert data['switches'][switch]['interfaces'][interface_id5]['enabled'] == True
+        assert data['interfaces'][interface_id4]['enabled'] == True
+        assert data['interfaces'][interface_id5]['enabled'] == True
 
         # WAIT for some time, until the feature kicks
         time.sleep(polling_time)
 
         # GET topology with the interface ensuring that they are enabled
-        api_url = KYTOS_API + '/topology/v3/switches' 
+        api_url = KYTOS_API + '/topology/v3/interfaces' 
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
-        assert 'switches' in data
-        assert data['switches'][switch]['interfaces'][interface_id4]['enabled'] == True
-        assert data['switches'][switch]['interfaces'][interface_id5]['enabled'] == True
+        assert data['interfaces'][interface_id4]['enabled'] == True
+        assert data['interfaces'][interface_id5]['enabled'] == True
 
 
     def test_020_reconfigure_ignored_loops(self):
@@ -105,16 +100,19 @@ class TestE2EOfLLDPLoopDetection:
         interface_id5 = "00:00:00:00:00:00:00:01:5"
 
         # GET topology with the interfaces ensuring that they are enabled
-        api_url = KYTOS_API + '/topology/v3/switches' 
+        api_url = KYTOS_API + '/topology/v3/interfaces' 
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
-        assert 'switches' in data
-        assert data['switches'][switch]['interfaces'][interface_id4]['enabled'] == True
-        assert data['switches'][switch]['interfaces'][interface_id5]['enabled'] == True
+        assert data['interfaces'][interface_id4]['enabled'] == True
+        assert data['interfaces'][interface_id5]['enabled'] == True
 
         # Reconfigure the ignored loop
-        api_url = KYTOS_API + '/topology/v3/switches/%s/metadata' % switch
+        api_url = KYTOS_API + '/topology/v3/interfaces/%s/metadata' % interface_id4
+        response = requests.post(api_url, json={"ignored_loops": []})
+        assert response.status_code == 200, response.text
+        
+        api_url = KYTOS_API + '/topology/v3/interfaces/%s/metadata' % interface_id5
         response = requests.post(api_url, json={"ignored_loops": []})
         assert response.status_code == 200, response.text
 
@@ -124,13 +122,12 @@ class TestE2EOfLLDPLoopDetection:
         time.sleep(polling_time)
 
         # GET topology with the interface ensuring that they are enabled
-        api_url = KYTOS_API + '/topology/v3/switches' 
+        api_url = KYTOS_API + '/topology/v3/interfaces' 
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
-        assert 'switches' in data
-        assert data['switches'][switch]['interfaces'][interface_id4]['enabled'] == True
-        assert data['switches'][switch]['interfaces'][interface_id5]['enabled'] == True
+        assert data['interfaces'][interface_id4]['enabled'] == True
+        assert data['interfaces'][interface_id5]['enabled'] == True
 
 
 

--- a/tests/test_e2e_31_of_lldp_loop_detection.py
+++ b/tests/test_e2e_31_of_lldp_loop_detection.py
@@ -39,12 +39,15 @@ class TestE2EOfLLDPLoopDetection:
 
         interface_id = "00:00:00:00:00:00:00:01:1"
 
-        # GET topology with the interface ensuring that it's enabled
-        api_url = KYTOS_API + '/topology/v3/interfaces' 
-        response = requests.get(api_url)
-        assert response.status_code == 200, response.text
-        data = response.json()
-        assert data['interfaces'][interface_id]['enabled'] == True
+        # GET topology with the interface ensuring that it's enabled.
+        # Loop detection relies on the POLLING_TIME, by default is 3 seconds, 
+        # the tests will pretty much start with the interface down. 
+
+        #api_url = KYTOS_API + '/topology/v3/interfaces' 
+        #response = requests.get(api_url)
+        #assert response.status_code == 200, response.text
+        #data = response.json()
+        #assert data['interfaces'][interface_id]['enabled'] == True
 
         # WAIT for some time, until the feature kicks
         time.sleep(polling_time)

--- a/tests/test_e2e_31_of_lldp_loop_detection.py
+++ b/tests/test_e2e_31_of_lldp_loop_detection.py
@@ -14,8 +14,8 @@ class TestE2EOfLLDPLoopDetection:
         cls.net = NetworkTest(CONTROLLER, topo_name='looped')
         cls.net.start()
         cls.net.restart_kytos_clean()
-        cls.net.wait_switches_connect()
-        time.sleep(10)
+        #cls.net.wait_switches_connect()
+        #time.sleep(10)
 
     @classmethod
     def teardown_class(cls):
@@ -63,9 +63,7 @@ class TestE2EOfLLDPLoopDetection:
 
         polling_time = 5
 
-        switch = '00:00:00:00:00:00:00:01'
         interface_id4 = "00:00:00:00:00:00:00:01:4"
-        interface_id5 = "00:00:00:00:00:00:00:01:5"
 
         # GET topology with the interfaces ensuring that they are enabled
         api_url = KYTOS_API + '/topology/v3/interfaces' 
@@ -73,22 +71,16 @@ class TestE2EOfLLDPLoopDetection:
         assert response.status_code == 200, response.text
         data = response.json()
         assert data['interfaces'][interface_id4]['enabled'] == True
-        assert data['interfaces'][interface_id5]['enabled'] == True
 
         # WAIT for some time, until the feature kicks
         time.sleep(polling_time)
 
         # GET topology with the interface ensuring that they are enabled
-        api_url = KYTOS_API + '/topology/v3/switches' 
+        api_url = KYTOS_API + '/topology/v3/interfaces' 
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
-        print(data['switches'][switch]['interfaces'][interface_id4]['metadata']) #looped in 
-        print(data['switches'][switch]['metadata']) #ignored_loops: [[4,5]] in
-        assert 'looped' in data['switches'][switch]['interfaces'][interface_id4]['metadata']
-        assert 'ignored_loops' in data['switches'][switch]['metadata']
-        assert data['switches'][switch]['interfaces'][interface_id4]['enabled'] == True
-        assert data['switches'][switch]['interfaces'][interface_id5]['enabled'] == True
+        assert data['interfaces'][interface_id4]['enabled'] == True  # [4,5] is an ignored loop
 
 
     def test_020_reconfigure_ignored_loops(self):
@@ -100,7 +92,6 @@ class TestE2EOfLLDPLoopDetection:
 
         switch = '00:00:00:00:00:00:00:01'
         interface_id4 = "00:00:00:00:00:00:00:01:4"
-        interface_id5 = "00:00:00:00:00:00:00:01:5"
 
         # GET topology with the interfaces ensuring that they are enabled
         api_url = KYTOS_API + '/topology/v3/interfaces' 
@@ -108,7 +99,6 @@ class TestE2EOfLLDPLoopDetection:
         assert response.status_code == 200, response.text
         data = response.json()
         assert data['interfaces'][interface_id4]['enabled'] == True
-        assert data['interfaces'][interface_id5]['enabled'] == True
 
         # WAIT for some time, until the feature kicks
         time.sleep(polling_time)
@@ -121,14 +111,11 @@ class TestE2EOfLLDPLoopDetection:
         self.restart()
 
         # GET topology with the interface ensuring that they are enabled
-        api_url = KYTOS_API + '/topology/v3/switches' 
+        api_url = KYTOS_API + '/topology/v3/interfaces' 
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
-        print(data['switches'][switch]['interfaces'][interface_id4]['metadata']) #looped in 
-        print(data['switches'][switch]['metadata']) #ignored_loops: [] 
-        assert data['switches'][switch]['interfaces'][interface_id4]['enabled'] == False
-        assert data['switches'][switch]['interfaces'][interface_id5]['enabled'] == False
+        assert data['interfaces'][interface_id4]['enabled'] == False # [4,5] is an ignored loop, it was reconfigured
 
 
 

--- a/tests/test_e2e_32_of_lldp.py
+++ b/tests/test_e2e_32_of_lldp.py
@@ -13,9 +13,9 @@ class TestE2EOfLLDPLoopDetection:
     def setup_class(cls):
         cls.net = NetworkTest(CONTROLLER, topo_name='looped')
         cls.net.start()
-        cls.net.restart_kytos_clean()
-        #cls.net.wait_switches_connect()
-        #time.sleep(10)
+        cls.net.start_controller(enable_all=True)
+        cls.net.wait_switches_connect()
+        time.sleep(10)
 
     @classmethod
     def teardown_class(cls):
@@ -38,18 +38,7 @@ class TestE2EOfLLDPLoopDetection:
         polling_time = 5
 
         interface_id = "00:00:00:00:00:00:00:01:1"
-
-        # GET topology with the interface ensuring that it's enabled.
-        # Loop detection relies on the POLLING_TIME, by default is 3 seconds, 
-        # the tests will pretty much start with the interface down. 
-
-        #api_url = KYTOS_API + '/topology/v3/interfaces' 
-        #response = requests.get(api_url)
-        #assert response.status_code == 200, response.text
-        #data = response.json()
-        #assert data['interfaces'][interface_id]['enabled'] == True
-
-        # WAIT for some time, until the feature kicks
+    
         time.sleep(polling_time)
 
         # GET topology with the interface ensuring that it's disabled

--- a/tests/test_e2e_32_of_lldp.py
+++ b/tests/test_e2e_32_of_lldp.py
@@ -108,11 +108,3 @@ class TestE2EOfLLDPLoopDetection:
         assert response.status_code == 200, response.text
         data = response.json()
         assert data['interfaces'][interface_id4]['enabled'] == False # [4,5] is an ignored loop, it was reconfigured
-
-
-
-
-
-
-
-        


### PR DESCRIPTION
Fixes #125

Added TestE2EOfLLDPLoopDetection to test that given a looped topology, it is going to disable the interface, unless it is an ignored loop.

This PR depends on this branch of_lldp https://github.com/kytos-ng/of_lldp/pull/36.

I run the e2e test and it's passing:

+ python3 -m pytest tests/test_e2e_32_of_lldp.py
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /tests
plugins: timeout-2.0.2
collected 3 items

tests/test_e2e_32_of_lldp.py ...                                         [100%]

================== 3 passed, 22 warnings in 95.88s (0:01:35) ===================
