### PR TITLE
Increasing wait time in test_085_end_running_mw_on_switch e2e_15

### DIFF
--- a/tests/test_e2e_15_maintenance.py
+++ b/tests/test_e2e_15_maintenance.py
@@ -877,7 +877,7 @@ class TestE2EMaintenance:
         assert end_response.status_code == 200
 
         # Waits just a couple of seconds to give kytos enough time to restore the flows
-        time.sleep(4)
+        time.sleep(5)
 
         # Verifies the flow behavior and connectivity after ending the maintenance
         flows_s2 = s2.dpctl('dump-flows')

--- a/tests/test_e2e_15_maintenance.py
+++ b/tests/test_e2e_15_maintenance.py
@@ -877,7 +877,7 @@ class TestE2EMaintenance:
         assert end_response.status_code == 200
 
         # Waits just a couple of seconds to give kytos enough time to restore the flows
-        time.sleep(3)
+        time.sleep(4)
 
         # Verifies the flow behavior and connectivity after ending the maintenance
         flows_s2 = s2.dpctl('dump-flows')


### PR DESCRIPTION
Fixes #138 

The test passes by increasing the waiting time in the test from 3 to 4 seconds. So, the test failure is solved by increasing the time to give Kytos more time to redeploy the EVC.

I repeated the test 10 times and it passed every time:

================== 1 passed, 34 warnings in 139.33s (0:02:19) ==================
+ for i in {1..10}
+ echo 'testing iteration 9'
testing iteration 9
+ python3 -m pytest tests/test_e2e_15_maintenance.py::TestE2EMaintenance::test_085_end_running_mw_on_switch
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /tests
plugins: timeout-2.0.2
collected 1 item

tests/test_e2e_15_maintenance.py .                                       [100%]

=============================== warnings summary ===============================
test_e2e_15_maintenance.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <

test_e2e_15_maintenance.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )

-- Docs: https://docs.pytest.org/en/stable/warnings.html
------------------------------- start/stop times -------------------------------
================== 1 passed, 34 warnings in 150.73s (0:02:30) ==================