### PR TITLE
[Fix] Adjust MEF E-Line tests to also consider failover_path flows

### DIFF
--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -13,6 +13,8 @@ KYTOS_API = 'http://%s:8181/api/kytos' % CONTROLLER
 
 TIME_FMT = "%Y-%m-%dT%H:%M:%S+0000"
 
+RE_I=re.IGNORECASE
+
 # BasicFlows
 # Each should have at least 3 flows, considering topology 'ring':
 # - 01 for LLDP
@@ -166,13 +168,15 @@ class TestE2EMefEline:
         assert 'circuit_id' in data
         time.sleep(10)
 
-        # Each switch must have BASIC_FLOWS + 02 for the EVC (ingress + egress)
+        # search for the cookie, should have three flows:
+        #  - 2 for the current path
+        #  - 1 for the failover path
         s1, s2 = self.net.net.get('s1', 's2')
         flows_s1 = s1.dpctl('dump-flows')
         flows_s2 = s2.dpctl('dump-flows')
 
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 2
-        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 2
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 3
+        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 3
 
         # make sure it should be dl_vlan instead of vlan_vid
         assert 'dl_vlan=15' in flows_s1
@@ -217,12 +221,14 @@ class TestE2EMefEline:
         assert 'circuit_id' in data
         time.sleep(10)
 
-        # Each switch must have BASIC_FLOWS + 02 for the EVC (ingress + egress)
+        # Each switch must have BASIC_FLOWS + 03 for the EVC:
+        #  - 2 for current path (ingress + egress)
+        #  - 1 for failover path
         s1, s2 = self.net.net.get('s1', 's2')
         flows_s1 = s1.dpctl('dump-flows')
         flows_s2 = s2.dpctl('dump-flows')
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 2
-        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 2
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 3
+        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 3
 
         # make sure it should be dl_vlan instead of vlan_vid
         assert 'dl_vlan=102' in flows_s1
@@ -266,12 +272,14 @@ class TestE2EMefEline:
         assert 'circuit_id' in data
         time.sleep(10)
 
-        # Each switch must have BASIC_FLOWS + 02 for the EVC (ingress + egress)
+        # Each switch must have BASIC_FLOWS + 03 for the EVC:
+        #  - 2 for current path (ingress + egress)
+        #  - 1 for failover path
         s1, s2 = self.net.net.get('s1', 's2')
         flows_s1 = s1.dpctl('dump-flows')
         flows_s2 = s2.dpctl('dump-flows')
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 2
-        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 2
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 3
+        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 3
 
         # make sure it should be dl_vlan instead of vlan_vid
         assert 'dl_vlan=104' in flows_s1
@@ -341,15 +349,16 @@ class TestE2EMefEline:
         assert evc1 != evc2
         time.sleep(10)
 
-        # Switch should have BASIC_FLOWS + 02 for evc1 + 02 for evc2
-        # The switches 2 and 3 should have BASIC_FLOWS + 02 for evc
+        # Switch s1 should have BASIC_FLOWS + 3 for evc1 + 3 for evc2
+        # Switch s2 should have BASIC_FLOWS + 3 for evc1 + 2 for evc2/failover
+        # Switch s2 should have BASIC_FLOWS + 3 for evc2 + 2 for evc1/failover
         s1, s2, s3 = self.net.net.get('s1', 's2', 's3')
         flows_s1 = s1.dpctl('dump-flows')
         flows_s2 = s2.dpctl('dump-flows')
         flows_s3 = s3.dpctl('dump-flows')
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 4
-        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 2
-        assert len(flows_s3.split('\r\n ')) == BASIC_FLOWS + 2
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 6
+        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 5
+        assert len(flows_s3.split('\r\n ')) == BASIC_FLOWS + 5
 
         # make sure it should be dl_vlan instead of vlan_vid
         assert 'dl_vlan=110' in flows_s1
@@ -501,12 +510,14 @@ class TestE2EMefEline:
         assert evc1 != evc2
         time.sleep(10)
 
-        # Each switch must have BASIC_FLOWS + 02 for the EVC (ingress + egress)
+        # Each switch must have BASIC_FLOWS + 03 for the EVC:
+        #  - 2 for current path (ingress + egress)
+        #  - 1 for failover path
         s1, s2 = self.net.net.get('s1', 's2')
         flows_s1 = s1.dpctl('dump-flows')
         flows_s2 = s2.dpctl('dump-flows')
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 2
-        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 2
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 3
+        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 3
 
         # Nodes should be able to ping each other
         h11, h2 = self.net.net.get('h11', 'h2')
@@ -560,7 +571,9 @@ class TestE2EMefEline:
 
         time.sleep(10)
 
-        # Each switch must have BASIC_FLOWS + 02 for the EVC (ingress + egress)
+        # Each switch must have BASIC_FLOWS + 02 for the EVC:
+        #  - 2 for current path (ingress + egress)
+        #  - (there will be no failover path)
         s1, s2, s3 = self.net.net.get('s1', 's2', 's3')
         flows_s1 = s1.dpctl('dump-flows')
         flows_s2 = s2.dpctl('dump-flows')
@@ -691,9 +704,17 @@ class TestE2EMefEline:
                 # search for the vlan id
                 assert "dl_vlan=%s" % vid in flows_s1
                 assert "dl_vlan=%s" % vid in flows_s2
-                # search for the cookie, should have two flows
-                assert len(re.findall(evc['id'], flows_s1, flags=re.IGNORECASE)) == 2, "round=%d - should have 2 flows but had: \n%s" % (x, flows_s1)
-                assert len(re.findall(evc['id'], flows_s2, flags=re.IGNORECASE)) == 2, "round=%d - should have 2 flows but had: \n%s" % (x, flows_s2)
+                # search for the cookie, should have three flows:
+                #  - 2 for the current path
+                #  - 1 for the failover path
+                assert (
+                    len(re.findall(evc['id'], flows_s1, flags=RE_I)) == 3,
+                    f"round={x} - should have 3 flows but had: \n{flows_s1}"
+                )
+                assert (
+                    len(re.findall(evc['id'], flows_s2, flags=RE_I)) == 3,
+                    f"round={x} - should have 3 flows but had: \n{flows_s2}"
+                )
 
             # Delete the circuits
             for vid in evcs:
@@ -754,11 +775,17 @@ class TestE2EMefEline:
             # search for the vlan id
             assert "dl_vlan=%s" % vid in flows_s1
             assert "dl_vlan=%s" % vid in flows_s2
-            # search for the cookie, should have two flows
-            assert len(re.findall(evc['id'], flows_s1, flags=re.IGNORECASE)) == 2, \
-                "should have 2 flows but had: \n%s" % flows_s1
-            assert len(re.findall(evc['id'], flows_s2, flags=re.IGNORECASE)) == 2, \
-                "should have 2 flows but had: \n%s" % flows_s2
+            # search for the cookie, should have three flows:
+            #  - 2 for the current path
+            #  - 1 for the failover path
+            assert (
+                len(re.findall(evc['id'], flows_s1, flags=RE_I)) == 3,
+                "should have 3 flows but had: \n%s" % flows_s1
+            )
+            assert (
+                len(re.findall(evc['id'], flows_s2, flags=RE_I)) == 3,
+                "should have 3 flows but had: \n%s" % flows_s2
+            )
 
         # Delete the circuits
         for vid in self.evcs:


### PR DESCRIPTION
This PR is related to kytos-ng/mef_eline#175

### Description of the change

With the introduction of the failover path on fully dynamic EVCs (those in which `dynamic_backup_path = True and not primary_path and not backup_path`), the number of flows in the flow table grew a bit. Thus, some end-to-end tests had to be adjusted accordingly.

The basic idea of the failover path is described in EP029, but below is the important part that impacts this PR:

> Let's take Topology 1 as the first example. Suppose that the best path will be set up to S - X - W - D. The maximum disjoint path (to be used as a failover path) will be set up to S - Z - W - I - D. The following OpenFlow rules will be created before a link failure:
> 
> OpenFlow rules for the primary path:
> - h1 -> S -> X -> W -> D -> h2
> - h2 -> D -> W -> X -> S -> h1
> 
> OpenFlow rules for the failover path:
> - S -> Z -> W -> I -> D -> h2
> - D -> I -> W -> Z -> S -> h1

The takeaway from the above description is basically: switches that are UNIs will have an extra flow for the failover path (the egress flow, which is pre-installed -- just for information: during a failure, the ingress flow will be then installed); switches that are in the path will have two extra flows for the failover path (the entire path is pre-installed).

In summary, this PR adjusts the tests that create fully dynamic EVCs to consider the aforementioned extra flows.

Results of the execution of the end-to-end tests (together with MEF E-Line's failover branch) can be seen below:

```
tests/test_e2e_01_kytos_startup.py ..                                    [  1%]
tests/test_e2e_05_topology.py ..................                         [ 10%]
tests/test_e2e_10_mef_eline.py .........X.......x....x.....              [ 24%]
tests/test_e2e_11_mef_eline.py .....                                     [ 26%]
tests/test_e2e_12_mef_eline.py .....xx.                                  [ 30%]
tests/test_e2e_13_mef_eline.py .....xxXx......xxXx.XXxX.xxxx..x......... [ 51%]
...                                                                      [ 52%]
tests/test_e2e_14_mef_eline.py x                                         [ 53%]
tests/test_e2e_15_maintenance.py ........................                [ 65%]
tests/test_e2e_20_flow_manager.py ................                       [ 73%]
tests/test_e2e_21_flow_manager.py ..                                     [ 74%]
tests/test_e2e_22_flow_manager.py ...............                        [ 81%]
tests/test_e2e_23_flow_manager.py X......................                [ 93%]
tests/test_e2e_30_of_lldp.py ....                                        [ 95%]
tests/test_e2e_31_of_lldp.py ...                                         [ 96%]
tests/test_e2e_32_of_lldp.py ...                                         [ 98%]
tests/test_e2e_40_sdntrace.py X.x                                        [100%]

==== 173 passed, 18 xfailed, 8 xpassed, 732 warnings in 10604.21s (2:56:44) ====
```