### PR TITLE
[Fix] MW flaky test case

### DIFF
--- a/tests/test_e2e_15_maintenance.py
+++ b/tests/test_e2e_15_maintenance.py
@@ -115,7 +115,7 @@ class TestE2EMaintenance:
         assert 'mw_id' in data
 
         # Waits for the MW to start
-        time.sleep(mw_start_delay + 10)
+        time.sleep(mw_start_delay + mw_duration / 4)
 
         # Switch 1 and 3 should have 3 flows; Switch 2 should have only 1 flow.
         s1, s2, s3 = self.net.net.get('s1', 's2', 's3')


### PR DESCRIPTION
Fixes #145

This PR is on topf of PR #147 

The test case looks good, I've explored it, looks like it's a convergence issue, where a flow hasn't been deleted yet in the switch, no false positives or consistency check reinstalling them though. I've slightly increase the sleep to have an extra time before checking the flows, that should suffice, I believe, I've run 5 iterations locally:

```
root@be0714fb5efc:/# cat script.sh
#!/bin/bash

for i in {1..5}
do
   echo "Running iteration $i..."
   python3 -m pytest tests/ --timeout=360 -k test_010_create_mw_on_switch_should_move_evc
   sleep 10
done
root@be0714fb5efc:/# grep -i "consistency" /var/log/messages

============================================================== 1 passed, 198 deselected, 34 warnings in 226.82s (0:03:46) ===============================================================
Running iteration 5...
================================================================================== test session starts ==================================================================================
platform linux -- Python 3.9.2, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /tests
plugins: timeout-2.0.2
timeout: 360.0s
timeout method: signal
timeout func_only: False
collected 199 items / 198 deselected / 1 selected

tests/test_e2e_15_maintenance.py .                                                                                                                                                [100%]

============================================================== 1 passed, 198 deselected, 34 warnings in 237.06s (0:03:57) ===============================================================
root@be0714fb5efc:/# cat script.sh


```