### PR TITLE
Included dump-flows str in asserts that are comparing the length

### DIFF
--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -131,7 +131,7 @@ class TestE2EMefEline:
         flows_s1 = s1.dpctl('dump-flows')
 
         # Each switch must have BASIC_FLOWS + 02 for the EVC (ingress + egress)
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 2
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 2, flows_s1
 
         # TODO: make sure it should be dl_vlan instead of vlan_vid
         assert 'dl_vlan=101' in flows_s1
@@ -175,8 +175,8 @@ class TestE2EMefEline:
         flows_s1 = s1.dpctl('dump-flows')
         flows_s2 = s2.dpctl('dump-flows')
 
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 3
-        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 3
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 3, flows_s1
+        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 3, flows_s2
 
         # make sure it should be dl_vlan instead of vlan_vid
         assert 'dl_vlan=15' in flows_s1
@@ -227,8 +227,8 @@ class TestE2EMefEline:
         s1, s2 = self.net.net.get('s1', 's2')
         flows_s1 = s1.dpctl('dump-flows')
         flows_s2 = s2.dpctl('dump-flows')
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 3
-        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 3
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 3, flows_s1
+        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 3, flows_s2
 
         # make sure it should be dl_vlan instead of vlan_vid
         assert 'dl_vlan=102' in flows_s1
@@ -278,8 +278,8 @@ class TestE2EMefEline:
         s1, s2 = self.net.net.get('s1', 's2')
         flows_s1 = s1.dpctl('dump-flows')
         flows_s2 = s2.dpctl('dump-flows')
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 3
-        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 3
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 3, flows_s1
+        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 3, flows_s2
 
         # make sure it should be dl_vlan instead of vlan_vid
         assert 'dl_vlan=104' in flows_s1
@@ -356,9 +356,9 @@ class TestE2EMefEline:
         flows_s1 = s1.dpctl('dump-flows')
         flows_s2 = s2.dpctl('dump-flows')
         flows_s3 = s3.dpctl('dump-flows')
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 6
-        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 5
-        assert len(flows_s3.split('\r\n ')) == BASIC_FLOWS + 5
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 6, flows_s1
+        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 5, flows_s2
+        assert len(flows_s3.split('\r\n ')) == BASIC_FLOWS + 5, flows_s3
 
         # make sure it should be dl_vlan instead of vlan_vid
         assert 'dl_vlan=110' in flows_s1
@@ -441,8 +441,8 @@ class TestE2EMefEline:
         s1, s2 = self.net.net.get('s1', 's2')
         flows_s1 = s1.dpctl('dump-flows')
         flows_s2 = s2.dpctl('dump-flows')
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS
-        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS, flows_s1
+        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS, flows_s2
 
         # Nodes should not be able to ping each other
         h11, h2 = self.net.net.get('h11', 'h2')
@@ -516,8 +516,8 @@ class TestE2EMefEline:
         s1, s2 = self.net.net.get('s1', 's2')
         flows_s1 = s1.dpctl('dump-flows')
         flows_s2 = s2.dpctl('dump-flows')
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 3
-        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 3
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 3, flows_s1
+        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 3, flows_s2
 
         # Nodes should be able to ping each other
         h11, h2 = self.net.net.get('h11', 'h2')
@@ -579,9 +579,9 @@ class TestE2EMefEline:
         flows_s2 = s2.dpctl('dump-flows')
         flows_s3 = s3.dpctl('dump-flows')
 
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 2
-        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 2
-        assert len(flows_s3.split('\r\n ')) == BASIC_FLOWS + 2
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 2, flows_s1
+        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 2, flows_s2
+        assert len(flows_s3.split('\r\n ')) == BASIC_FLOWS + 2, flows_s3
 
         # Command to up/down links to test if back-up path is taken
         self.net.net.configLinkStatus('s1', 's2', 'down')

--- a/tests/test_e2e_11_mef_eline.py
+++ b/tests/test_e2e_11_mef_eline.py
@@ -97,10 +97,10 @@ class TestE2EMefEline:
         flows_s2 = s2.dpctl('dump-flows')
         flows_s3 = s3.dpctl('dump-flows')
         flows_s4 = s4.dpctl('dump-flows')
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 2
-        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 2
-        assert len(flows_s3.split('\r\n ')) == BASIC_FLOWS + 2
-        assert len(flows_s4.split('\r\n ')) == BASIC_FLOWS + 2
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 2, flows_s1
+        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 2, flows_s2
+        assert len(flows_s3.split('\r\n ')) == BASIC_FLOWS + 2, flows_s3
+        assert len(flows_s4.split('\r\n ')) == BASIC_FLOWS + 2, flows_s4
 
         # Nodes should be able to ping each other
         h1, h3 = self.net.net.get('h1', 'h3')
@@ -160,10 +160,10 @@ class TestE2EMefEline:
         flows_s2 = s2.dpctl('dump-flows')
         flows_s3 = s3.dpctl('dump-flows')
         flows_s4 = s4.dpctl('dump-flows')
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 2
-        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 2
-        assert len(flows_s3.split('\r\n ')) == BASIC_FLOWS + 2
-        assert len(flows_s4.split('\r\n ')) == BASIC_FLOWS + 2
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 2, flows_s1
+        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 2, flows_s2
+        assert len(flows_s3.split('\r\n ')) == BASIC_FLOWS + 2, flows_s3
+        assert len(flows_s4.split('\r\n ')) == BASIC_FLOWS + 2, flows_s4
 
         # Nodes should be able to ping each other
         h1, h3 = self.net.net.get('h1', 'h3')
@@ -222,10 +222,10 @@ class TestE2EMefEline:
         flows_s3 = s3.dpctl('dump-flows')
         flows_s4 = s4.dpctl('dump-flows')
 
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 2
-        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 2
-        assert len(flows_s3.split('\r\n ')) == BASIC_FLOWS + 2
-        assert len(flows_s4.split('\r\n ')) == BASIC_FLOWS + 2
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 2, flows_s1
+        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 2, flows_s2
+        assert len(flows_s3.split('\r\n ')) == BASIC_FLOWS + 2, flows_s3
+        assert len(flows_s4.split('\r\n ')) == BASIC_FLOWS + 2, flows_s4
 
         # Nodes should be able to ping each other
         h1, h3 = self.net.net.get('h1', 'h3')
@@ -268,10 +268,10 @@ class TestE2EMefEline:
         flows_s2 = s2.dpctl('dump-flows')
         flows_s3 = s3.dpctl('dump-flows')
         flows_s4 = s4.dpctl('dump-flows')
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 2
-        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS
-        assert len(flows_s3.split('\r\n ')) == BASIC_FLOWS
-        assert len(flows_s4.split('\r\n ')) == BASIC_FLOWS
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 2, flows_s1
+        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS, flows_s2
+        assert len(flows_s3.split('\r\n ')) == BASIC_FLOWS, flows_s3
+        assert len(flows_s4.split('\r\n ')) == BASIC_FLOWS, flows_s4
 
         # Nodes should be able to ping each other
         h1, h2 = self.net.net.get('h1', 'h2')

--- a/tests/test_e2e_12_mef_eline.py
+++ b/tests/test_e2e_12_mef_eline.py
@@ -287,7 +287,7 @@ class TestE2EMefEline:
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
         # Each switch had BASIC_FLOWS flows + 02 for the EVC (ingress + egress)
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 2
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 2, flows_s1
 
     """Error, start_date should be patched only if the Evc
     has been created under the scheduler action
@@ -386,4 +386,4 @@ class TestE2EMefEline:
         flows_s1 = s1.dpctl('dump-flows')
         # Each switch had BASIC_FLOWS flows + 02 for the EVC (ingress + egress)
         # at this point the flow number should be reduced to BASIC_FLOWS
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS, flows_s1

--- a/tests/test_e2e_15_maintenance.py
+++ b/tests/test_e2e_15_maintenance.py
@@ -122,9 +122,9 @@ class TestE2EMaintenance:
         flows_s1 = s1.dpctl('dump-flows')
         flows_s2 = s2.dpctl('dump-flows')
         flows_s3 = s3.dpctl('dump-flows')
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 2
-        assert len(flows_s3.split('\r\n ')) == BASIC_FLOWS + 2
-        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 2, flows_s1
+        assert len(flows_s3.split('\r\n ')) == BASIC_FLOWS + 2, flows_s3
+        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS, flows_s2
 
         # Makes sure it should be dl_vlan instead of vlan_vid
         assert 'dl_vlan=100' in flows_s1
@@ -148,7 +148,7 @@ class TestE2EMaintenance:
         time.sleep(mw_duration)
 
         flows_s2 = s2.dpctl('dump-flows')
-        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 2
+        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 2, flows_s2
         result = h11.cmd('ping -c1 100.0.0.2')
         assert ', 0% packet loss,' in result
 
@@ -332,7 +332,7 @@ class TestE2EMaintenance:
         s2 = self.net.net.get('s2')
         flows_s2 = s2.dpctl('dump-flows')
         assert 'dl_vlan=100' not in flows_s2
-        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS
+        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS, flows_s2
 
         # Checks connectivity during maintenance
         h11, h3 = self.net.net.get('h11', 'h3')
@@ -677,7 +677,7 @@ class TestE2EMaintenance:
         # Verifies the flow at the initial MW time
         # (no maintenance at that time, it has been delayed)
         flows_s2 = s2.dpctl('dump-flows')
-        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 2
+        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 2, flows_s2
         result = h11.cmd('ping -c1 100.0.0.2')
         assert ', 0% packet loss,' in result
 
@@ -687,7 +687,7 @@ class TestE2EMaintenance:
         # Verifies the flow during maintenance time
         flows_s2 = s2.dpctl('dump-flows')
         assert 'dl_vlan=100' not in flows_s2
-        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS
+        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS, flows_s2
         result = h11.cmd('ping -c1 100.0.0.2')
         assert ', 0% packet loss,' in result
 
@@ -800,7 +800,7 @@ class TestE2EMaintenance:
         # Verifies the flow behavior
         # (no maintenance at that time, it has been deleted)
         flows_s2 = s2.dpctl('dump-flows')
-        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 2
+        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 2, flows_s2
         result = h11.cmd('ping -c1 100.0.0.2')
         assert ', 0% packet loss,' in result
 
@@ -887,7 +887,7 @@ class TestE2EMaintenance:
 
         # Verifies the flow behavior and connectivity after ending the maintenance
         flows_s2 = s2.dpctl('dump-flows')
-        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 2
+        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 2, flows_s2
         result = h11.cmd('ping -c1 100.0.0.2')
         assert ', 0% packet loss,' in result
 
@@ -993,7 +993,7 @@ class TestE2EMaintenance:
         s2 = self.net.net.get('s2')
         flows_s2 = s2.dpctl('dump-flows')
         assert 'dl_vlan=100' not in flows_s2
-        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS
+        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS, flows_s2
 
         # Checks connectivity during maintenance
         h11, h3 = self.net.net.get('h11', 'h3')
@@ -1020,7 +1020,7 @@ class TestE2EMaintenance:
         s2 = self.net.net.get('s2')
         flows_s2 = s2.dpctl('dump-flows')
         assert 'dl_vlan=100' not in flows_s2
-        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS
+        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS, flows_s2
 
         # Checks connectivity during maintenance
         h11, h3 = self.net.net.get('h11', 'h3')
@@ -1038,7 +1038,7 @@ class TestE2EMaintenance:
 
         # Verifies the flows behavior after the maintenance
         flows_s2 = s2.dpctl('dump-flows')
-        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 2
+        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 2, flows_s2
         result = h11.cmd('ping -c1 100.0.0.2')
         assert ', 0% packet loss,' in result
 

--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -80,7 +80,7 @@ class TestE2EFlowManager:
 
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1, flows_s1
         assert 'actions=output:"s1-eth2"' in flows_s1
 
     def test_010_install_flow_and_retrieve_it_back(self):
@@ -175,7 +175,7 @@ class TestE2EFlowManager:
         for sw_name in ['s1', 's2', 's3']:
             sw = self.net.net.get(sw_name)
             flows_sw = sw.dpctl('dump-flows')
-            assert len(flows_sw.split('\r\n ')) == BASIC_FLOWS + 1
+            assert len(flows_sw.split('\r\n ')) == BASIC_FLOWS + 1, flows_sw
             assert 'actions=output:"%s-eth2"' % sw_name in flows_sw
 
     def test_020_delete_flow(self):
@@ -227,7 +227,7 @@ class TestE2EFlowManager:
 
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS, flows_s1
         assert 'actions=output:"s1-eth2"' not in flows_s1
 
     def test_025_delete_flows(self):
@@ -280,7 +280,7 @@ class TestE2EFlowManager:
         for sw_name in ['s1', 's2', 's3']:
             sw = self.net.net.get(sw_name)
             flows_sw = sw.dpctl('dump-flows')
-            assert len(flows_sw.split('\r\n ')) == BASIC_FLOWS
+            assert len(flows_sw.split('\r\n ')) == BASIC_FLOWS, flows_sw
             assert 'actions=output:"%s-eth2"' % sw_name not in flows_sw
 
     def modify_match(self, restart_kytos=False):
@@ -326,7 +326,7 @@ class TestE2EFlowManager:
 
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1, flows_s1
         assert 'in_port="s1-eth1' in flows_s1
 
     def test_030_modify_match(self):
@@ -366,7 +366,7 @@ class TestE2EFlowManager:
         # Verify the flow
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1, flows_s1
         assert 'in_port="s1-eth1' in flows_s1
 
         # Modify the actions and verify its modification
@@ -385,7 +385,7 @@ class TestE2EFlowManager:
         # Check that the flow keeps the original setting
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1, flows_s1
         assert 'actions=output:"s1-eth3"' not in flows_s1
         assert 'in_port="s1-eth1' in flows_s1
 
@@ -423,7 +423,7 @@ class TestE2EFlowManager:
         # Verify the flow
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1, flows_s1
         assert 'in_port="s1-eth1' in flows_s1
 
         s1.dpctl('add-flow', 'in_port=1,idle_timeout=360,hard_timeout=1200,priority=10,actions=strip_vlan,output:2')
@@ -436,7 +436,7 @@ class TestE2EFlowManager:
         time.sleep(10)
 
         flows_s1 = s1.dpctl('dump-flows')
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1, flows_s1
         assert 'actions=strip_vlan,' not in flows_s1
         assert 'actions=output:"s1-eth2' in flows_s1
 
@@ -461,7 +461,7 @@ class TestE2EFlowManager:
 
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS, flows_s1
 
     def test_060_flow_another_table(self):
         self.flow_another_table()
@@ -485,7 +485,7 @@ class TestE2EFlowManager:
 
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS, flows_s1
 
     def test_070_flow_table_0(self):
         self.flow_table_0()

--- a/tests/test_e2e_21_flow_manager.py
+++ b/tests/test_e2e_21_flow_manager.py
@@ -85,7 +85,7 @@ class TestE2EFlowManager:
 
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1, flows_s1
         for flow in flows_s1.split('\r\n '):
             # Check all flows but the of_lldp, which is reinstalled
             if 'dl_vlan=999' not in flow: continue
@@ -134,5 +134,5 @@ class TestE2EFlowManager:
         time.sleep(10)
 
         flows_s1 = s1.dpctl('dump-flows')
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1, flows_s1
         assert 'dl_vlan=999' in flows_s1

--- a/tests/test_e2e_23_flow_manager.py
+++ b/tests/test_e2e_23_flow_manager.py
@@ -110,7 +110,7 @@ class TestE2EFlowManager:
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
 
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 3
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 3, flows_s1
         assert 'actions=output:"s1-eth2"' in flows_s1
 
         payload2 = {
@@ -132,7 +132,7 @@ class TestE2EFlowManager:
         time.sleep(10)
 
         flows_s1 = s1.dpctl('dump-flows')
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 3
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 3, flows_s1
 
         assert 'actions=output:"s1-eth3"' in flows_s1
         assert 'actions=output:"s1-eth4"' in flows_s1
@@ -202,7 +202,7 @@ class TestE2EFlowManager:
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
 
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 3
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 3, flows_s1
         assert 'actions=output:"s1-eth2"' in flows_s1
 
         payload2 = {
@@ -223,7 +223,7 @@ class TestE2EFlowManager:
         time.sleep(10)
 
         flows_s1 = s1.dpctl('dump-flows')
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 4
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 4, flows_s1
 
         assert 'actions=output:"s1-eth2"' in flows_s1
         assert 'actions=output:"s1-eth3"' in flows_s1
@@ -294,7 +294,7 @@ class TestE2EFlowManager:
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
 
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 3
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 3, flows_s1
         assert 'actions=output:"s1-eth2"' in flows_s1
 
         payload2 = {
@@ -318,7 +318,7 @@ class TestE2EFlowManager:
         time.sleep(10)
 
         flows_s1 = s1.dpctl('dump-flows')
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 4
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 4, flows_s1
 
         assert 'actions=output:"s1-eth2"' in flows_s1
         assert 'actions=output:"s1-eth3"' in flows_s1
@@ -373,7 +373,7 @@ class TestE2EFlowManager:
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
 
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 2
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 2, flows_s1
         assert 'actions=output:"s1-eth2"' in flows_s1
 
         payload2 = {
@@ -421,7 +421,7 @@ class TestE2EFlowManager:
 
         flows_s1 = s1.dpctl('dump-flows')
 
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 4
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 4, flows_s1
 
         assert 'actions=output:"s1-eth2"' in flows_s1
         assert 'actions=output:"s1-eth3"' in flows_s1
@@ -477,7 +477,7 @@ class TestE2EFlowManager:
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
 
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 2
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 2, flows_s1
         assert 'actions=output:"s1-eth2"' in flows_s1
         assert 'actions=output:"s1-eth3"' in flows_s1
 
@@ -513,7 +513,7 @@ class TestE2EFlowManager:
 
         flows_s1 = s1.dpctl('dump-flows')
 
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 3
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 3, flows_s1
         assert 'actions=output:"s1-eth2"' in flows_s1
         assert 'actions=output:"s1-eth3"' in flows_s1
         assert 'in_port="s1-eth3"' in flows_s1
@@ -546,7 +546,7 @@ class TestE2EFlowManager:
 
         flows_s1 = s1.dpctl('dump-flows')
 
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 4
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 4, flows_s1
 
         assert 'in_port="s1-eth4"' in flows_s1
         assert 'actions=output:"s1-eth1"' in flows_s1
@@ -624,7 +624,7 @@ class TestE2EFlowManager:
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
 
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1, flows_s1
         assert 'actions=output:"s1-eth2"' in flows_s1
 
     def test_035_install_flow(self):
@@ -661,7 +661,7 @@ class TestE2EFlowManager:
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
 
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1, flows_s1
         assert 'actions=output:"s1-eth2"' in flows_s1
 
         api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
@@ -673,7 +673,7 @@ class TestE2EFlowManager:
 
         flows_s1 = s1.dpctl('dump-flows')
 
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1, flows_s1
         assert 'actions=output:"s1-eth2"' in flows_s1
 
         api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
@@ -685,7 +685,7 @@ class TestE2EFlowManager:
 
         flows_s1 = s1.dpctl('dump-flows')
 
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1, flows_s1
         assert 'actions=output:"s1-eth2"' in flows_s1
 
     def test_040_install_flow(self):
@@ -765,7 +765,7 @@ class TestE2EFlowManager:
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
 
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1, flows_s1
         assert 'actions=output:"s1-eth2"' in flows_s1
 
     def test_045_install_flow(self):
@@ -803,7 +803,7 @@ class TestE2EFlowManager:
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
 
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1, flows_s1
         assert 'actions=output:"s1-eth2"' in flows_s1
 
         api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
@@ -815,7 +815,7 @@ class TestE2EFlowManager:
 
         flows_s1 = s1.dpctl('dump-flows')
 
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1, flows_s1
         assert 'actions=output:"s1-eth2"' in flows_s1
 
         api_url = KYTOS_API + '/flow_manager/v2/flows/00:00:00:00:00:00:00:01'
@@ -827,7 +827,7 @@ class TestE2EFlowManager:
 
         flows_s1 = s1.dpctl('dump-flows')
 
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1, flows_s1
         assert 'actions=output:"s1-eth2"' in flows_s1
 
     def test_050_install_flow(self):
@@ -879,7 +879,7 @@ class TestE2EFlowManager:
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
 
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 2
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 2, flows_s1
         assert 'actions=output:"s1-eth2"' in flows_s1
 
     def test_055_install_flow(self):
@@ -917,7 +917,7 @@ class TestE2EFlowManager:
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
 
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1, flows_s1
         assert 'actions=output:"s1-eth2"' in flows_s1
 
         payload1 = {
@@ -948,7 +948,7 @@ class TestE2EFlowManager:
 
         flows_s1 = s1.dpctl('dump-flows')
 
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 2
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 2, flows_s1
         assert 'actions=output:"s1-eth2"' in flows_s1
 
     def test_060_install_flow(self):
@@ -1001,7 +1001,7 @@ class TestE2EFlowManager:
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
 
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 2
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 2, flows_s1
         assert 'actions=output:"s1-eth2"' in flows_s1
         assert 'actions=output:"s1-eth3"' in flows_s1
 
@@ -1022,7 +1022,7 @@ class TestE2EFlowManager:
 
         flows_s1 = s1.dpctl('dump-flows')
 
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 3
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 3, flows_s1
         assert 'actions=drop' in flows_s1
 
     def test_065_install_flow(self):
@@ -1064,7 +1064,7 @@ class TestE2EFlowManager:
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
 
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 100
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 100, flows_s1
 
     def create_flow(self, vlan_id):
         payload = {
@@ -1108,4 +1108,4 @@ class TestE2EFlowManager:
 
         s1 = self.net.net.get('s1')
         flows_s1 = s1.dpctl('dump-flows')
-        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 100
+        assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 100, flows_s1

--- a/tests/test_e2e_31_of_lldp.py
+++ b/tests/test_e2e_31_of_lldp.py
@@ -210,7 +210,7 @@ class TestE2EOfLLDP:
         s2 = self.net.net.get('s2')
         flows_s2 = s2.dpctl("dump-flows")
         # Expects 2x LLDP flow entries
-        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 1
+        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 1, flows_s2
 
         # Assert GET liveness/ is enabled and down
         api_url = f"{KYTOS_API}/of_lldp/v1/liveness/?interface_id={interface_ids[1]}"
@@ -237,7 +237,7 @@ class TestE2EOfLLDP:
         s2 = self.net.net.get('s2')
         flows_s2 = s2.dpctl("dump-flows")
         # Expects 1x LLDP flow entry
-        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS
+        assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS, flows_s2
 
         # Assert GET liveness/ is enabled and up
         api_url = f"{KYTOS_API}/of_lldp/v1/liveness/?interface_id={interface_ids[1]}"


### PR DESCRIPTION
Fixes #150 

- Included dump-flows str in asserts that are comparing the length

So, now if it fails you should get an assertion with more context to figure out why it failed:

```
>       assert len(flows_s1.split('\r\n ')) == BASIC_FLOWS + 1, flows_s1
E       AssertionError:  cookie=0x0, duration=97.948s, table=0, n_packets=0, n_bytes=0, priority=50000,dl_src=ee:ee:ee:ee:ee:03 actions=CONTROLLER:65535
E          cookie=0x0, duration=97.943s, table=0, n_packets=0, n_bytes=0, priority=50000,dl_src=ee:ee:ee:ee:ee:02 actions=CONTROLLER:65535
E          cookie=0xaaa35c0d3d2c814a, duration=15.343s, table=0, n_packets=0, n_bytes=0, in_port="s1-eth1",dl_vlan=100 actions=mod_vlan_vid:100,mod_vlan_vid:3537,output:"s1-eth4"
E          cookie=0xaaa35c0d3d2c814a, duration=15.342s, table=0, n_packets=0, n_bytes=0, in_port="s1-eth4",dl_vlan=3537 actions=strip_vlan,output:"s1-eth1"
E          cookie=0xab00000000000001, duration=98.196s, table=0, n_packets=61, n_bytes=2562, priority=1000,dl_vlan=3799,dl_type=0x88cc actions=CONTROLLER:65535
```

In the future we can further minimize the length of the output by filtering out by the cookie prefix (depending on each test case focus) when using `dump-flows`

