### PR TITLE
[Fix] `test_start_kytos_api_core` test case, removed scheduler from the expected list

### DIFF
--- a/tests/test_e2e_01_kytos_startup.py
+++ b/tests/test_e2e_01_kytos_startup.py
@@ -60,7 +60,6 @@ class TestE2EKytosServer:
                 ("kytos", "topology"),
                 ("kytos", "of_lldp"),
                 ('amlight', 'sdntrace'),
-                ('amlight', 'scheduler'),
                 ('amlight', 'flow_stats'),
                 ('amlight', 'coloring'),
                 ('amlight', 'sdntrace_cp'),


### PR DESCRIPTION

Fixed `test_start_kytos_api_core` test case, removed scheduler from the expected list:

```
+ python3 -m pytest tests/ -k test_start_kytos_api_core
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /tests
plugins: timeout-2.0.2
collected 199 items / 198 deselected / 1 selected

tests/test_e2e_01_kytos_startup.py .                                     [100%]

=============================== warnings summary ===============================
test_e2e_01_kytos_startup.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <

test_e2e_01_kytos_startup.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )

-- Docs: https://docs.pytest.org/en/stable/warnings.html
------------------------------- start/stop times -------------------------------
=============== 1 passed, 198 deselected, 34 warnings in 53.08s ================
```