### PR TITLE
Updated mef_eline priority as sb_priority

### DIFF
--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -926,21 +926,22 @@ class TestE2EMefEline:
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
-        priority = 100
+        sb_priority = 100
         payload = {
-            "priority": priority
+            "sb_priority": sb_priority
         }
 
-        # It sets a new circuit's priority
-        requests.patch(api_url + evc1, data=json.dumps(payload),
-                       headers={'Content-type': 'application/json'})
+        # It sets a new circuit's sb_priority
+        response = requests.patch(api_url + evc1, data=json.dumps(payload),
+                                  headers={'Content-type': 'application/json'})
+        assert response.status_code == 200, response.text
 
         time.sleep(10)
 
         # It verifies EVC's data
         response = requests.get(api_url + evc1)
         data = response.json()
-        assert data['priority'] == priority
+        assert data['sb_priority'] == sb_priority, data
 
         s1, s2 = self.net.net.get('s1', 's2')
         flows_s1 = s1.dpctl('dump-flows')


### PR DESCRIPTION
Fixes #161 

### With this PR and `mef_eline` feature/service_level branch

```
+ python3 -m pytest tests/ -k test_115_patch_priority
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /tests
plugins: timeout-2.0.2
collected 199 items / 198 deselected / 1 selected

tests/test_e2e_10_mef_eline.py .                                         [100%]

=============================== warnings summary ===============================
test_e2e_10_mef_eline.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <

test_e2e_10_mef_eline.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )

-- Docs: https://docs.pytest.org/en/stable/warnings.html
------------------------------- start/stop times -------------------------------
========== 1 passed, 198 deselected, 34 warnings in 78.54s (0:01:18) ===========
+ tail -f
```

### With `mef_eline` feature/service_level branch and without updating the test:

```
+ python3 -m pytest tests/ -k test_115_patch_priority
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /tests
plugins: timeout-2.0.2
collected 199 items / 198 deselected / 1 selected

tests/test_e2e_10_mef_eline.py F                                         [100%]

=================================== FAILURES ===================================
___________________ TestE2EMefEline.test_115_patch_priority ____________________

self = <tests.test_e2e_10_mef_eline.TestE2EMefEline object at 0x7fd1d41d0880>

    def test_115_patch_priority(self):

        api_url = KYTOS_API + '/mef_eline/v2/evc/'
        evc1 = self.create_evc(100)

        priority = 100
        payload = {
            "priority": priority
        }

        # It sets a new circuit's priority
        requests.patch(api_url + evc1, data=json.dumps(payload),
                       headers={'Content-type': 'application/json'})

        time.sleep(10)

        # It verifies EVC's data
        response = requests.get(api_url + evc1)
        data = response.json()
>       assert data['priority'] == priority
E       KeyError: 'priority'

tests/test_e2e_10_mef_eline.py:943: KeyError

```