### PR TITLE
Slightly increase a sleep and also updated an assert to match stricter

### DIFF
--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -219,7 +219,7 @@ class TestE2EMefEline:
         assert response.status_code == 201, response.text
         data = response.json()
         assert 'circuit_id' in data
-        time.sleep(10)
+        time.sleep(15)
 
         # Each switch must have BASIC_FLOWS + 03 for the EVC:
         #  - 2 for current path (ingress + egress)
@@ -231,8 +231,8 @@ class TestE2EMefEline:
         assert len(flows_s2.split('\r\n ')) == BASIC_FLOWS + 3, flows_s2
 
         # make sure it should be dl_vlan instead of vlan_vid
-        assert 'dl_vlan=102' in flows_s1
-        assert 'dl_vlan=103' in flows_s2
+        assert 'in_port="s1-eth1",dl_vlan=102' in flows_s1
+        assert 'in_port="s2-eth1",dl_vlan=103' in flows_s2
 
         # Make the final and most important test: connectivity
         # 1. create the vlans and setup the ip addresses


### PR DESCRIPTION
Enhanced #160, this is on top of PR #170 

As highlighted on this comment https://github.com/amlight/kytos-end-to-end-tests/issues/160#issuecomment-1278151550, this fix here won't completely mitigate the issue, but I took the opportunity to slightly increase a sleep there and also to make an assert stricter, I ran it locally three times, let's keep an eye on this one:

```
+ for i in {1..3}
+ echo 'iteration 3'
iteration 3
+ python3 -m pytest -s -vv --timeout=300 tests/ -k test_025_create_evc_different_tags_each_side
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /tests
plugins: timeout-2.0.2
timeout: 300.0s
timeout method: signal
timeout func_only: False
collecting ... collected 199 items / 198 deselected / 1 selected

*** Error setting resource limits. Mininet's performance may be affected.
tests/test_e2e_10_mef_eline.py::TestE2EMefEline::test_025_create_evc_different_tags_each_side PASSED

=============================== warnings summary ===============================
test_e2e_10_mef_eline.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <

test_e2e_10_mef_eline.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )

-- Docs: https://docs.pytest.org/en/stable/warnings.html
------------------------------- start/stop times -------------------------------
========== 1 passed, 198 deselected, 34 warnings in 98.00s (0:01:37) ===========

``` 