### PR TITLE
Increased `CONSISTENCY_MIN_VERDICT_INTERVAL` and adapted tests

### DIFF
--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -4,8 +4,8 @@ set -xe
 
 # the settings below are intended to decrease the tests execution time (in fact, the time.sleep() calls
 # depend on the values below, otherwise many tests would fail)
-sed -i 's/STATS_INTERVAL = 60/STATS_INTERVAL = 3/g' /var/lib/kytos/napps/kytos/of_core/settings.py
-sed -i 's/CONSISTENCY_MIN_VERDICT_INTERVAL =.*/CONSISTENCY_MIN_VERDICT_INTERVAL = 3/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
+sed -i 's/STATS_INTERVAL = 60/STATS_INTERVAL = 30/g' /var/lib/kytos/napps/kytos/of_core/settings.py
+sed -i 's/CONSISTENCY_MIN_VERDICT_INTERVAL =.*/CONSISTENCY_MIN_VERDICT_INTERVAL = 60/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
 sed -i 's/LINK_UP_TIMER = 10/LINK_UP_TIMER = 1/g' /var/lib/kytos/napps/kytos/topology/settings.py
 sed -i 's/DEPLOY_EVCS_INTERVAL = 60/DEPLOY_EVCS_INTERVAL = 5/g' /var/lib/kytos/napps/kytos/mef_eline/settings.py
 sed -i 's/LLDP_LOOP_ACTIONS = \["log"\]/LLDP_LOOP_ACTIONS = \["disable","log"\]/' /var/lib/kytos/napps/kytos/of_lldp/settings.py

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -325,15 +325,15 @@ class NetworkTest:
         self.start_controller(clean_config=True, enable_all=True)
         self.wait_switches_connect()
 
-    def reconnect_switches(self, target="tcp:127.0.0.1:6653", min_delay=3):
+    def reconnect_switches(self, target="tcp:127.0.0.1:6653"):
         """Restart switches connections.
         This method can also be used to trigger a consistency check initial run."""
         for sw in self.net.switches:
-            sw.vsctl(f'del-controller {sw.name}')
+            sw.vsctl(f"del-controller {sw.name}")
         for sw in self.net.switches:
-            sw.vsctl(f'set-controller {sw.name} {target}')
-        # Min delay to avoid introducing other delays since TCP reconn is quick
-        time.sleep(min_delay)
+            sw.vsctl(f"set-controller {sw.name} {target}")
+            sw.controllerUUIDs(update=True)
+        self.wait_switches_connect()
 
     def config_all_links_up(self):
         for link in self.net.links:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -325,6 +325,16 @@ class NetworkTest:
         self.start_controller(clean_config=True, enable_all=True)
         self.wait_switches_connect()
 
+    def reconnect_switches(self, target="tcp:127.0.0.1:6653", min_delay=3):
+        """Restart switches connections.
+        This method can also be used to trigger a consistency check initial run."""
+        for sw in self.net.switches:
+            sw.vsctl(f'del-controller {sw.name}')
+        for sw in self.net.switches:
+            sw.vsctl(f'set-controller {sw.name} {target}')
+        # Min delay to avoid introducing other delays since TCP reconn is quick
+        time.sleep(min_delay)
+
     def config_all_links_up(self):
         for link in self.net.links:
             self.net.configLinkStatus(

--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -364,6 +364,8 @@ class TestE2EFlowManager:
             # restart controller keeping configuration
             self.net.start_controller(enable_all=True)
             self.net.wait_switches_connect()
+        else:
+            self.net.reconnect_switches()
 
         time.sleep(10)
 
@@ -422,6 +424,8 @@ class TestE2EFlowManager:
             # restart controller keeping configuration
             self.net.start_controller(enable_all=True)
             self.net.wait_switches_connect()
+        else:
+            self.net.reconnect_switches()
 
         time.sleep(10)
 
@@ -499,6 +503,8 @@ class TestE2EFlowManager:
             # restart controller keeping configuration
             self.net.start_controller(enable_all=True)
             self.net.wait_switches_connect()
+        else:
+            self.net.reconnect_switches()
 
         time.sleep(10)
 
@@ -523,6 +529,8 @@ class TestE2EFlowManager:
             # restart controller keeping configuration
             self.net.start_controller(enable_all=True)
             self.net.wait_switches_connect()
+        else:
+            self.net.reconnect_switches()
 
         time.sleep(10)
 

--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -141,16 +141,22 @@ class TestE2EFlowManager:
 
         time.sleep(10)
 
-        response = requests.get(api_url)
+        sw_name = "s1"
+        sw = self.net.net.get(sw_name)
+        flows_sw = sw.dpctl("dump-flows")
+        assert len(flows_sw.split('\r\n ')) == BASIC_FLOWS + 1, flows_sw
+        assert 'actions=output:"%s-eth2"' % sw_name in flows_sw
+
+        stored_flows = f'{KYTOS_API}/flow_manager/v2/stored_flows/?dpids={switch_id}'
+        response = requests.get(stored_flows)
         assert response.status_code == 200, response.text
         data = response.json()
-        assert len(data[switch_id]["flows"]) == BASIC_FLOWS + 1
-        assert data[switch_id]["flows"][-1]["instructions"][0]["instruction_type"] == "apply_actions"
-        assert data[switch_id]["flows"][-1]['instructions'][0]["actions"] == payload["flows"][0]["actions"]
-        assert data[switch_id]["flows"][-1]["match"] == payload["flows"][0]["match"]
-        assert data[switch_id]["flows"][-1]["priority"] == payload["flows"][0]["priority"]
-        assert data[switch_id]["flows"][-1]["idle_timeout"] == payload["flows"][0]["idle_timeout"]
-        assert data[switch_id]["flows"][-1]["hard_timeout"] == payload["flows"][0]["hard_timeout"]
+        assert len(data[switch_id]) == BASIC_FLOWS + 1
+        assert data[switch_id][-1]["flow"]["actions"] == payload["flows"][0]["actions"]
+        assert data[switch_id][-1]["flow"]["match"] == payload["flows"][0]["match"]
+        assert data[switch_id][-1]["flow"]["priority"] == payload["flows"][0]["priority"]
+        assert data[switch_id][-1]["flow"]["idle_timeout"] == payload["flows"][0]["idle_timeout"]
+        assert data[switch_id][-1]["flow"]["hard_timeout"] == payload["flows"][0]["hard_timeout"]
 
     def test_015_install_flows(self):
         """Tests if, after kytos restart, a flow installed
@@ -479,6 +485,8 @@ class TestE2EFlowManager:
             # restart controller keeping configuration
             self.net.start_controller(enable_all=True)
             self.net.wait_switches_connect()
+        else:
+            self.net.reconnect_switches()
 
         time.sleep(10)
 

--- a/tests/test_e2e_20_flow_manager.py
+++ b/tests/test_e2e_20_flow_manager.py
@@ -553,7 +553,7 @@ class TestE2EFlowManager:
         self.flow_table_0(restart_kytos=True)
 
     def test_080_retrieve_flows(self):
-        api_url = KYTOS_API + '/flow_manager/v2/flows'
+        api_url = KYTOS_API + '/flow_manager/v2/stored_flows'
         response = requests.get(api_url)
         assert response.status_code == 200, response.text
         data = response.json()
@@ -561,6 +561,6 @@ class TestE2EFlowManager:
         assert "00:00:00:00:00:00:00:01" in data.keys()
         assert "00:00:00:00:00:00:00:02" in data.keys()
         assert "00:00:00:00:00:00:00:03" in data.keys()
-        assert len(data["00:00:00:00:00:00:00:01"]["flows"]) == BASIC_FLOWS
-        assert len(data["00:00:00:00:00:00:00:02"]["flows"]) == BASIC_FLOWS
-        assert len(data["00:00:00:00:00:00:00:03"]["flows"]) == BASIC_FLOWS
+        assert len(data["00:00:00:00:00:00:00:01"]) == BASIC_FLOWS
+        assert len(data["00:00:00:00:00:00:00:02"]) == BASIC_FLOWS
+        assert len(data["00:00:00:00:00:00:00:03"]) == BASIC_FLOWS

--- a/tests/test_e2e_21_flow_manager.py
+++ b/tests/test_e2e_21_flow_manager.py
@@ -129,6 +129,8 @@ class TestE2EFlowManager:
         # so to simulate that, we just delete all flows
         s1 = self.net.net.get('s1')
         s1.dpctl('del-flows')
+        # reconnect to trigger and speed up consistency check after the handshake
+        self.net.reconnect_switches()
 
         # wait for the flow to be installed
         time.sleep(10)

--- a/tests/test_e2e_23_flow_manager.py
+++ b/tests/test_e2e_23_flow_manager.py
@@ -40,12 +40,6 @@ class TestE2EFlowManager:
     def teardown_class(cls):
         cls.net.stop()
 
-    #
-    # Issue: https://github.com/kytos-ng/flow_manager/issues/23
-    #
-    @pytest.mark.xfail
-    #@pytest.mark.parametrize('execution_number', range(10))
-    #def test_005_install_flow(self, execution_number):
     def test_005_install_flow(self):
         """
         Tests the inclusion of a flow with matches fields and
@@ -230,8 +224,7 @@ class TestE2EFlowManager:
         assert 'actions=output:"s1-eth4"' in flows_s1
         assert 'actions=drop' in flows_s1
 
-    @pytest.mark.parametrize('execution_number', range(10))
-    def test_015_install_flow(self, execution_number):
+    def test_015_install_flow(self):
         """
         Tests the inclusion of a flow without match fields and
         with one action after the creation of a set of flows


### PR DESCRIPTION
Fixes #172 

- Increased `CONSISTENCY_MIN_VERDICT_INTERVAL` to 60 (this is the half the value we have by default), so the consistency check, after an OF handshake will only kick in after this interval at least, so this helps out to avoid having premature consistency check runs that would lead to slower convergence and false positive asserts during convergence (if we have any asserts going on during convergence).
 - Increased `STATS_INTERVAL` to 30 to minimize the overhead of FlowStats messages and decrease a bit of IO/CPU on OvS instances. This interval was initially low intentionally to avoid waiting too much for flows to be installed again and trigger the consistency check. Since the consistency check is triggered after the initial handshake/flow stats reply https://github.com/kytos-ng/flow_manager/pull/115, then we can also trigger this by forcing a TCP reconnection by setting the controller on the switches again, check out the `reconnect_switches()` helper method that has been implemented, and has been used on test cases where it was expected that the consistency check would've run at that point. In the future, I think we could also have an endpoint on flow_manager to force triggering the consistency check to run on demand, but we probably won't need in the short term.
 - Removed an `xfail` from test_005_install_flow since it's been fixed. 
 - Removed `parametrize('execution_number', range(10))` repeated executions since the tests marked with it haven't been flaky.
 - Overall the tests took 2h50, I avoid trying to speed up any other the existing `sleep` to not introduce new variables in the meantime, since there are other issues like issue #173 that hasn't been fixed yet. It's saved 10 mins because of the `parametrize` repetition that was removed. 
 
 I tested this branch with `flow_manager` branch on AmLight's GitLab CI, it's passing:
 
 
 ```
 $ ./kytos-init.sh
+ sed -i 's/STATS_INTERVAL = 60/STATS_INTERVAL = 30/g' /var/lib/kytos/napps/kytos/of_core/settings.py
+ sed -i 's/CONSISTENCY_MIN_VERDICT_INTERVAL =.*/CONSISTENCY_MIN_VERDICT_INTERVAL = 60/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
+ sed -i 's/LINK_UP_TIMER = 10/LINK_UP_TIMER = 1/g' /var/lib/kytos/napps/kytos/topology/settings.py
+ sed -i 's/DEPLOY_EVCS_INTERVAL = 60/DEPLOY_EVCS_INTERVAL = 5/g' /var/lib/kytos/napps/kytos/mef_eline/settings.py
+ sed -i 's/LLDP_LOOP_ACTIONS = \["log"\]/LLDP_LOOP_ACTIONS = \["disable","log"\]/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
+ sed -i 's/LLDP_IGNORED_LOOPS = {}/LLDP_IGNORED_LOOPS = {"00:00:00:00:00:00:00:01": \[\[4, 5\]\]}/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
+ sed -i 's/CONSISTENCY_COOKIE_IGNORED_RANGE =.*/CONSISTENCY_COOKIE_IGNORED_RANGE = [(0xdd00000000000000, 0xdd00000000000009)]/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
+ sed -i 's/LIVENESS_DEAD_MULTIPLIER =.*/LIVENESS_DEAD_MULTIPLIER = 3/g' /var/lib/kytos/napps/kytos/of_lldp/settings.py
+ kytosd --help
+ sed -i s/WARNING/INFO/g /etc/kytos/logging.ini
+ test -z tests/
+ python3 scripts/wait_for_mongo.py
Trying to run hello command on MongoDB...
Trying to run 'hello' command on MongoDB...
Ran 'hello' command on MongoDB successfully. It's ready!
+ python3 -m pytest tests/
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: timeout-2.0.2
collected 191 items
tests/test_e2e_01_kytos_startup.py ..                                    [  1%]
tests/test_e2e_05_topology.py ..................                         [ 10%]
tests/test_e2e_10_mef_eline.py .........Xss.....x....x.....              [ 25%]
tests/test_e2e_11_mef_eline.py .....                                     [ 27%]
tests/test_e2e_12_mef_eline.py .....xx.                                  [ 31%]
tests/test_e2e_13_mef_eline.py .....xxXx......xxXx.XXxX.xxxx..x......... [ 53%]
...                                                                      [ 54%]
tests/test_e2e_14_mef_eline.py x                                         [ 55%]
tests/test_e2e_15_maintenance.py ........................                [ 68%]
tests/test_e2e_15_mef_eline.py .                                         [ 68%]
tests/test_e2e_20_flow_manager.py ................                       [ 76%]
tests/test_e2e_21_flow_manager.py ..                                     [ 78%]
tests/test_e2e_22_flow_manager.py ...............                        [ 85%]
tests/test_e2e_23_flow_manager.py ..............                         [ 93%]
tests/test_e2e_30_of_lldp.py ....                                        [ 95%]
tests/test_e2e_31_of_lldp.py ...                                         [ 96%]
tests/test_e2e_32_of_lldp.py ...                                         [ 98%]
tests/test_e2e_40_sdntrace.py X.x                                        [100%]

= 164 passed, 2 skipped, 18 xfailed, 7 xpassed, 758 warnings in 10[140](https://gitlab.ampath.net/amlight/kytos-end-to-end-tester/-/jobs/34505#L140).69s (2:49:00) =
 ```