### PR TITLE
[Feat] Hooked `pytest-rerunfailures` 

### DIFF
--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -18,9 +18,10 @@ kytosd --help >/dev/null 2>&1  ## create configs at /etc/kytos from templates
 sed -i 's/WARNING/INFO/g' /etc/kytos/logging.ini
 
 test -z "$TESTS" && TESTS=tests/
+test -z "$RERUNS" && RERUNS=3
 
 python3 scripts/wait_for_mongo.py 2>/dev/null
-python3 -m pytest $TESTS
+python3 -m pytest $TESTS --reruns $RERUNS --only-rerun AssertionError -r fEr
 
 #tail -f
 

--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -18,7 +18,7 @@ kytosd --help >/dev/null 2>&1  ## create configs at /etc/kytos from templates
 sed -i 's/WARNING/INFO/g' /etc/kytos/logging.ini
 
 test -z "$TESTS" && TESTS=tests/
-test -z "$RERUNS" && RERUNS=3
+test -z "$RERUNS" && RERUNS=2
 
 python3 scripts/wait_for_mongo.py 2>/dev/null
 python3 -m pytest $TESTS --reruns $RERUNS --only-rerun AssertionError -r fEr

--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -21,7 +21,7 @@ test -z "$TESTS" && TESTS=tests/
 test -z "$RERUNS" && RERUNS=2
 
 python3 scripts/wait_for_mongo.py 2>/dev/null
-python3 -m pytest $TESTS --reruns $RERUNS --only-rerun AssertionError -r fEr
+python3 -m pytest $TESTS --reruns $RERUNS -r fEr
 
 #tail -f
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,15 +15,17 @@ def pytest_terminal_summary(terminalreporter):
     terminalreporter.section('start/stop times', sep='-', bold=True)
     for stat in terminalreporter.stats.values():
         for report in stat:
-            start = datetime.fromtimestamp(report.start)
-            stop = datetime.fromtimestamp(report.stop)
             if (
                 hasattr(report, "outcome")
                 and report.outcome == "rerun"
                 and report.when == "call"
             ):
                 terminalreporter.write_line(f"rerun: {report.rerun}")
+                start = datetime.fromtimestamp(report.start)
+                stop = datetime.fromtimestamp(report.stop)
                 terminalreporter.write_line('{id:20}: {start:%Y-%m-%d,%H:%M:%S.%f} - {stop:%Y-%m-%d,%H:%M:%S.%f}'.format(id=report.nodeid, start=start, stop=stop))
                 terminalreporter.write_line(f"{report.longrepr}")
             if hasattr(report, 'failed') and report.failed and report.when == 'call':
+                start = datetime.fromtimestamp(report.start)
+                stop = datetime.fromtimestamp(report.stop)
                 terminalreporter.write_line('{id:20}: {start:%Y-%m-%d,%H:%M:%S.%f} - {stop:%Y-%m-%d,%H:%M:%S.%f}'.format(id=report.nodeid, start=start, stop=stop))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,12 +9,21 @@ def pytest_runtest_makereport(item, call):
     report.start = call.start
     report.stop = call.stop
 
+
 def pytest_terminal_summary(terminalreporter):
     terminalreporter.ensure_newline()
     terminalreporter.section('start/stop times', sep='-', bold=True)
     for stat in terminalreporter.stats.values():
         for report in stat:
+            start = datetime.fromtimestamp(report.start)
+            stop = datetime.fromtimestamp(report.stop)
+            if (
+                hasattr(report, "outcome")
+                and report.outcome == "rerun"
+                and report.when == "call"
+            ):
+                terminalreporter.write_line(f"rerun: {report.rerun}")
+                terminalreporter.write_line('{id:20}: {start:%Y-%m-%d,%H:%M:%S.%f} - {stop:%Y-%m-%d,%H:%M:%S.%f}'.format(id=report.nodeid, start=start, stop=stop))
+                terminalreporter.write_line(f"{report.longrepr}")
             if hasattr(report, 'failed') and report.failed and report.when == 'call':
-                start = datetime.fromtimestamp(report.start)
-                stop = datetime.fromtimestamp(report.stop)
                 terminalreporter.write_line('{id:20}: {start:%Y-%m-%d,%H:%M:%S.%f} - {stop:%Y-%m-%d,%H:%M:%S.%f}'.format(id=report.nodeid, start=start, stop=stop))


### PR DESCRIPTION
Fixes #185

This is on top of PR #178 

- Hooked `pytest-rerunfailures` 
- Updated `pytest_terminal_summary` to also report reruns as shown here, same approach that Italo has contributed to help out to identify start and stop times, https://github.com/amlight/kytos-end-to-end-tests/pull/178#issuecomment-1315837807 to help us out when analyzing failures (check this comment/thread out for more context)

If you're running locally and creating new tests that aren't stable yet you can zero the RERUN var. By default, it'll try to rerun. 