### PR TITLE
Adding interfaces for JAX2 in the init script

### DIFF
--- a/kytos-amlight-topo-init.sh
+++ b/kytos-amlight-topo-init.sh
@@ -145,6 +145,9 @@ set_interface_enable_lldp_metadata 00:00:00:00:00:00:00:20:16 '{"mtu": 9000, "po
 set_interface_enable_lldp_metadata 00:00:00:00:00:00:00:20:17 '{"mtu": 9000, "port_name": "Interface-20:17"}'
 set_interface_enable_lldp_metadata 00:00:00:00:00:00:00:21:14 '{"mtu": 9000, "port_name": "Interface-21:14"}'
 set_interface_enable_lldp_metadata 00:00:00:00:00:00:00:21:18 '{"mtu": 9000, "port_name": "Interface-21:18"}'
+set_interface_enable_lldp_metadata 00:00:00:00:00:00:00:22:15 '{"mtu": 9000, "port_name": "Interface-22:15"}'
+set_interface_enable_lldp_metadata 00:00:00:00:00:00:00:22:18 '{"mtu": 9000, "port_name": "Interface-22:18"}'
+set_interface_enable_lldp_metadata 00:00:00:00:00:00:00:22:61 '{"mtu": 9000, "port_name": "Interface-22:61"}'
 
 
 #############################


### PR DESCRIPTION
This PR will add some interfaces that are missing for JAX2 switch from AmLight topo (`test/helpers.py`) in the `kytos-amlight-topo-init.sh`.

Without those interfaces, some links will never come up and the init script will fail.

This script is only used for manual tests, so no impact is expected.