### PR TITLE
[Fix] Fixed reconnect switches side effect and decreased `STATS_INTERVAL`

### DIFF
--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -4,7 +4,7 @@ set -xe
 
 # the settings below are intended to decrease the tests execution time (in fact, the time.sleep() calls
 # depend on the values below, otherwise many tests would fail)
-sed -i 's/STATS_INTERVAL = 60/STATS_INTERVAL = 30/g' /var/lib/kytos/napps/kytos/of_core/settings.py
+sed -i 's/STATS_INTERVAL = 60/STATS_INTERVAL = 7/g' /var/lib/kytos/napps/kytos/of_core/settings.py
 sed -i 's/CONSISTENCY_MIN_VERDICT_INTERVAL =.*/CONSISTENCY_MIN_VERDICT_INTERVAL = 60/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
 sed -i 's/LINK_UP_TIMER = 10/LINK_UP_TIMER = 1/g' /var/lib/kytos/napps/kytos/topology/settings.py
 sed -i 's/DEPLOY_EVCS_INTERVAL = 60/DEPLOY_EVCS_INTERVAL = 5/g' /var/lib/kytos/napps/kytos/mef_eline/settings.py

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -325,11 +325,17 @@ class NetworkTest:
         self.start_controller(clean_config=True, enable_all=True)
         self.wait_switches_connect()
 
-    def reconnect_switches(self, target="tcp:127.0.0.1:6653"):
+    def reconnect_switches(self, target="tcp:127.0.0.1:6653",
+                           temp_target="tcp:127.0.0.1:6654"):
         """Restart switches connections.
-        This method can also be used to trigger a consistency check initial run."""
+        This method can also be used to trigger a consistency check initial run.
+
+        A temporary target is used in order to avoid OvS deleting the flows
+        if the controller config were to be deleted.
+        """
         for sw in self.net.switches:
-            sw.vsctl(f"del-controller {sw.name}")
+            sw.vsctl(f"set-controller {sw.name} {temp_target}")
+            sw.controllerUUIDs(update=True)
         for sw in self.net.switches:
             sw.vsctl(f"set-controller {sw.name} {target}")
             sw.controllerUUIDs(update=True)


### PR DESCRIPTION
Fixes #188 
Fixes #189 

- Updated reconnect_switches to avoid deleting the OvS controller config
- Decreased STATS_INTERVAL to 7, since on PR https://github.com/amlight/kytos-end-to-end-tests/pull/178, I mostly decreased it to minimize IO overhead, using 7 it still with the most time.sleep(10) even after a forced OF reconnection/handshake that we have since the max interval to request flow stats [is upper bound to `% STATS_INTERVAL/2`](https://github.com/kytos-ng/of_core/blob/master/main.py#L92) depending on the size of the topology


I locally explored with the test `test_040_replace_action_flow` that @italovalcy reported:

```
+ sed -i 's/STATS_INTERVAL = 60/STATS_INTERVAL = 7/g' /var/lib/kytos/napps/kytos/of_core/settings.py
+ sed -i 's/CONSISTENCY_MIN_VERDICT_INTERVAL =.*/CONSISTENCY_MIN_VERDICT_INTERVAL = 60/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
+ sed -i 's/LINK_UP_TIMER = 10/LINK_UP_TIMER = 1/g' /var/lib/kytos/napps/kytos/topology/settings.py
+ sed -i 's/DEPLOY_EVCS_INTERVAL = 60/DEPLOY_EVCS_INTERVAL = 5/g' /var/lib/kytos/napps/kytos/mef_eline/settings.py
+ sed -i 's/LLDP_LOOP_ACTIONS = \["log"\]/LLDP_LOOP_ACTIONS = \["disable","log"\]/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
+ sed -i 's/LLDP_IGNORED_LOOPS = {}/LLDP_IGNORED_LOOPS = {"00:00:00:00:00:00:00:01": \[\[4, 5\]\]}/' /var/lib/kytos/napps/kytos/of_lldp/settings.py
+ sed -i 's/CONSISTENCY_COOKIE_IGNORED_RANGE =.*/CONSISTENCY_COOKIE_IGNORED_RANGE = [(0xdd00000000000000, 0xdd00000000000009)]/g' /var/lib/kytos/napps/kytos/flow_manager/settings.py
+ sed -i 's/LIVENESS_DEAD_MULTIPLIER =.*/LIVENESS_DEAD_MULTIPLIER = 3/g' /var/lib/kytos/napps/kytos/of_lldp/settings.py

========== 1 passed, 198 deselected, 35 warnings in 93.78s (0:01:33) ===========
iteration 5
+ for i in {1..5}
+ echo 'iteration 5'
+ python3 -m pytest tests/ --timeout=300 -k test_040_replace_action_flow
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.0.0
rootdir: /tests
plugins: rerunfailures-10.2, timeout-2.1.0
timeout: 300.0s
timeout method: signal
timeout func_only: False
collected 199 items / 198 deselected / 1 selected

tests/test_e2e_20_flow_manager.py .                                      [100%]

=============================== warnings summary ===============================

``` 


I'll dispatch an e2e full test execution with this branch. I'll post the results here later