### PR TITLE
Add test for get stored flows from flow_manager

### DIFF
--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -21,9 +21,9 @@ test -z "$TESTS" && TESTS=tests/
 test -z "$RERUNS" && RERUNS=2
 
 python3 scripts/wait_for_mongo.py 2>/dev/null
-#python3 -m pytest $TESTS --reruns $RERUNS -r fEr
+python3 -m pytest $TESTS --reruns $RERUNS -r fEr
 
 #tail -f
 
 # only run specific test
-python3 -m pytest tests/test_e2e_40_sdntrace.py::TestE2ESDNTrace::test_030_run_sdntrace_for_stored_flows
+# python3 -m pytest --timeout=60 tests/test_e2e_10_mef_eline.py::TestE2EMefEline::test_on_primary_path_fail_should_migrate_to_backup

--- a/kytos-init.sh
+++ b/kytos-init.sh
@@ -21,9 +21,9 @@ test -z "$TESTS" && TESTS=tests/
 test -z "$RERUNS" && RERUNS=2
 
 python3 scripts/wait_for_mongo.py 2>/dev/null
-python3 -m pytest $TESTS --reruns $RERUNS -r fEr
+#python3 -m pytest $TESTS --reruns $RERUNS -r fEr
 
 #tail -f
 
 # only run specific test
-# python3 -m pytest --timeout=60 tests/test_e2e_10_mef_eline.py::TestE2EMefEline::test_on_primary_path_fail_should_migrate_to_backup
+python3 -m pytest tests/test_e2e_40_sdntrace.py::TestE2ESDNTrace::test_030_run_sdntrace_for_stored_flows

--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -57,7 +57,6 @@ class TestE2ESDNTrace:
 
 
     # This test may eventually fail due to https://github.com/kytos-ng/flow_stats/issues/19
-    # @pytest.mark.xfail
     def test_001_run_sdntrace_cp(self):
         """Run SDNTrace-CP (Control Plane)."""
         # Trace from UNI_A
@@ -237,7 +236,6 @@ class TestE2ESDNTrace:
         assert expected == actual, f"Expected {expected}. Actual: {actual}"
 
     # This test may eventually fail due to https://github.com/kytos-ng/flow_stats/issues/19
-    # @pytest.mark.xfail
     def test_020_run_sdntrace_fail_missing_flow(self):
         """Run SDNTrace-CP with a failure due to missing flows:
         - delete flow from intermediate switch
@@ -379,7 +377,7 @@ class TestE2ESDNTrace:
 
     def test_030_run_sdntrace_for_stored_flows(self):
         """Run SDNTrace to get traces from flow_manager stored_flow"""
-        payload = {
+        payload = [{
                     "trace": {
                         "switch": {
                             "dpid": "00:00:00:00:00:00:00:01",
@@ -389,10 +387,11 @@ class TestE2ESDNTrace:
                             "dl_vlan": 100
                         }
                     }
-                }
+                }]
                 
-        api_url = KYTOS_API + '/amlight/sdntrace_cp/trace'
+        api_url = KYTOS_API + '/kytos-ng/sdntrace_cp/traces'
         response = requests.put(api_url, json=payload)
         assert response.status_code == 200, response.text
         data = response.json()
+        print(data)
         assert data['result'][0]['dpid'] == '00:00:00:00:00:00:00:01'

--- a/tests/test_e2e_40_sdntrace.py
+++ b/tests/test_e2e_40_sdntrace.py
@@ -57,7 +57,7 @@ class TestE2ESDNTrace:
 
 
     # This test may eventually fail due to https://github.com/kytos-ng/flow_stats/issues/19
-    @pytest.mark.xfail
+    # @pytest.mark.xfail
     def test_001_run_sdntrace_cp(self):
         """Run SDNTrace-CP (Control Plane)."""
         # Trace from UNI_A
@@ -237,7 +237,7 @@ class TestE2ESDNTrace:
         assert expected == actual, f"Expected {expected}. Actual: {actual}"
 
     # This test may eventually fail due to https://github.com/kytos-ng/flow_stats/issues/19
-    @pytest.mark.xfail
+    # @pytest.mark.xfail
     def test_020_run_sdntrace_fail_missing_flow(self):
         """Run SDNTrace-CP with a failure due to missing flows:
         - delete flow from intermediate switch
@@ -376,3 +376,23 @@ class TestE2ESDNTrace:
             (step['dpid'], step['port']) for step in result[1:-1]
         ]
         assert expected == actual, f"Expected {expected}. Actual: {actual}"
+
+    def test_030_run_sdntrace_for_stored_flows(self):
+        """Run SDNTrace to get traces from flow_manager stored_flow"""
+        payload = {
+                    "trace": {
+                        "switch": {
+                            "dpid": "00:00:00:00:00:00:00:01",
+                            "in_port": 1
+                        },
+                        "eth": {
+                            "dl_vlan": 100
+                        }
+                    }
+                }
+                
+        api_url = KYTOS_API + '/amlight/sdntrace_cp/trace'
+        response = requests.put(api_url, json=payload)
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert data['result'][0]['dpid'] == '00:00:00:00:00:00:00:01'


### PR DESCRIPTION
Fix #174 

 Add `test_e2e_40_sdntrace.py::TestE2ESDNTrace::test_030_run_sdntrace_for_stored_flows` to test how the traces are obtained from flow_manager stored_flow.

Also, `test_e2e_40_sdntrace.py::TestE2ESDNTrace::test_001_run_sdntrace_cp` hass passed. 