### PR TITLE
[fix] test_125_patch_dynamic_backup_path for mef_eline PR 233

### DIFF
--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -1000,18 +1000,26 @@ class TestE2EMefEline:
         assert 'set_queue:3' in flows_s2
 
     def test_125_patch_dynamic_backup_path(self):
+        """Test patching an EVC to be non dynamic with primary_path."""
 
         api_url = KYTOS_API + '/mef_eline/v2/evc/'
         evc1 = self.create_evc(100)
 
         dynamic_backup_path = False
         payload = {
-            "dynamic_backup_path": dynamic_backup_path
+            "dynamic_backup_path": dynamic_backup_path,
+            "primary_path": [
+                {
+                    "endpoint_a": {"id": "00:00:00:00:00:00:00:01:3"},
+                    "endpoint_b": {"id": "00:00:00:00:00:00:00:02:2"},
+                }
+            ],
         }
 
         # It sets a new circuit's dynamic_backup_path
-        requests.patch(api_url + evc1, data=json.dumps(payload),
-                       headers={'Content-type': 'application/json'})
+        response = requests.patch(api_url + evc1, data=json.dumps(payload),
+                                  headers={'Content-type': 'application/json'})
+        assert response.status_code == 200, response.text
 
         time.sleep(10)
 

--- a/tests/test_e2e_10_mef_eline.py
+++ b/tests/test_e2e_10_mef_eline.py
@@ -1028,6 +1028,22 @@ class TestE2EMefEline:
         data = response.json()
         assert data['dynamic_backup_path'] == dynamic_backup_path
 
+    def test_126_patch_dynamic_backup_path_false_no_primary_path(self):
+        """Test try to patch dynamic_backup_path as False with an EVC
+        that doesn't have a static primary_path."""
+
+        api_url = KYTOS_API + '/mef_eline/v2/evc/'
+        evc1 = self.create_evc(100)
+        payload = {
+            "dynamic_backup_path": False,
+        }
+        response = requests.patch(api_url + evc1, data=json.dumps(payload),
+                                  headers={'Content-type': 'application/json'})
+        assert response.status_code == 400, response.text
+        expected_err = "must have a primary path or allow dynamic paths"
+        data = response.json()
+        assert expected_err in data["description"]
+
     """The EVC is returning active=False"""
     @pytest.mark.xfail
     def test_130_patch_primary_path(self):


### PR DESCRIPTION

### Summary

- Fix test_125_patch_dynamic_backup_path for PR https://github.com/kytos-ng/mef_eline/pull/233, if `dynamic_backup_path` is false then it should have a `primary_path` set

### Local tests

I've tested it locally with `mef_eline` PR 233 (link mentioned above)

```
+ python3 -m pytest --timeout=600 tests/ -k test_125_patch_dynamic_backup_path
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.0.0
rootdir: /tests
plugins: rerunfailures-10.2, timeout-2.1.0
timeout: 600.0s
timeout method: signal
timeout func_only: False
collected 199 items / 198 deselected / 1 selected

tests/test_e2e_10_mef_eline.py .                                         [100%]

=============================== warnings summary ===============================
usr/local/lib/python3.9/dist-packages/kytos/core/config.py:186
  /usr/local/lib/python3.9/dist-packages/kytos/core/config.py:186: UserWarning: Unknown arguments: ['--timeout=600', 'tests/', '-k', 'test_125_patch_dynamic_backup_path']
    warnings.warn(f"Unknown arguments: {unknown}")

test_e2e_10_mef_eline.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1121: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    return ( StrictVersion( cls.OVSVersion ) <

test_e2e_10_mef_eline.py: 17 warnings
  /usr/lib/python3/dist-packages/mininet/node.py:1122: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    StrictVersion( '1.10' ) )

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
========== 1 passed, 198 deselected, 35 warnings in 78.09s (0:01:18) ===========
+ tail -f

```